### PR TITLE
Trim space in extraEnvSafelist

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -25,7 +25,7 @@ function throwMissingEnvVar(name: string): never {
 
 function listExtraEnv(): ExtraEnv {
   const extraEnvSafelist = core.getInput('extraEnvSafelist')
-  const safeList = (extraEnvSafelist || '').split(',')
+  const safeList = (extraEnvSafelist || '').split(',').map(item => item.trim())
 
   const extraEnv = Object.keys(process.env)
     .filter(name => {


### PR DESCRIPTION
Hello,

If there are spaces in `extraEnvSafelist`, like in this example:
```
extraEnvSafelist: |
            PYTHON_VERSION, PYTHON_BACKEND, CC_FS_BUCKET
```

The matching will fail.
In order to fix it, I propose to add a trim on all element after the split.

Regards
Damien