### PR TITLE
Env refactoring

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,3 +44,11 @@ jobs:
           name: 47ng/actions-clever-cloud
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          tag script: |
+            const tag = context.ref
+              .replace('refs/heads/', '')
+              .replace('refs/tags/', '')
+              .replace('refs/pull/', '')
+              .replace(/\//g, '_')
+              .replace(/#/g, '');
+            return tag === 'master' ? 'latest' : tag;

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,6 @@ jobs:
     name: Deployment
     needs: ci
     runs-on: ubuntu-latest
-    if: ${{ github.ref_name == 'master' }}
     steps:
       - uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675
       - uses: manusa/actions-publish-docker@db938e45d2a3487e0eab9646e83550f554c17af3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675
       - uses: actions/setup-node@56899e050abffc08c2b3b61f3ec6a79a9dc3223d
         with:
-          node-version: 14.x
+          node-version: 16.x
       - uses: actions/cache@d1255ad9362389eac595a9ae406b8e8cb3331f16
         name: Load Yarn cache
         with:
@@ -36,6 +36,7 @@ jobs:
     name: Deployment
     needs: ci
     runs-on: ubuntu-latest
+    if: ${{ github.ref_name == 'master' }}
     steps:
       - uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675
       - uses: manusa/actions-publish-docker@db938e45d2a3487e0eab9646e83550f554c17af3

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+yarn ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mhart/alpine-node:14 AS builder
+FROM mhart/alpine-node:16 AS builder
 
 WORKDIR /action
 
@@ -13,7 +13,7 @@ RUN yarn install --production
 
 # ---
 
-FROM mhart/alpine-node:14 AS final
+FROM mhart/alpine-node:16 AS final
 
 WORKDIR /action
 COPY --from=builder /action .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mhart/alpine-node:16 AS builder
+FROM node:16-bullseye AS builder
 
 WORKDIR /action
 
@@ -13,9 +13,8 @@ RUN yarn install --production
 
 # ---
 
-FROM mhart/alpine-node:16 AS final
+FROM node:16-bullseye AS final
 
-WORKDIR /action
 COPY --from=builder /action .
 
 CMD node /action/dist/main.js

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Marketplace](https://img.shields.io/github/v/release/47ng/actions-clever-cloud?label=Marketplace)](https://github.com/marketplace/actions/deploy-to-clever-cloud)
 [![MIT License](https://img.shields.io/github/license/47ng/actions-clever-cloud.svg?color=blue)](https://github.com/47ng/actions-clever-cloud/blob/master/LICENSE)
 [![CI/CD](https://github.com/47ng/actions-clever-cloud/workflows/CI/CD/badge.svg)](https://github.com/47ng/actions-clever-cloud/actions)
-[![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=47ng/actions-clever-cloud)](https://dependabot.com)
 [![Average issue resolution time](https://isitmaintained.com/badge/resolution/47ng/actions-clever-cloud.svg)](https://isitmaintained.com/project/47ng/actions-clever-cloud)
 [![Number of open issues](https://isitmaintained.com/badge/open/47ng/actions-clever-cloud.svg)](https://isitmaintained.com/project/47ng/actions-clever-cloud)
 
@@ -159,3 +158,9 @@ Clever Cloud lets you connect your GitHub repository so that any push is
 deployed. This is great for staging environments, but in some cases you
 may want to deploy to production only on specific events, like a release
 being published, or after a CI run.
+
+## License
+
+[MIT](https://github.com/47ng/actions-clever-cloud/blob/master/LICENSE) - Made with ❤️ by [François Best](https://francoisbest.com)
+
+Using this action at work ? [Sponsor me](https://github.com/sponsors/franky47) to help with support and maintenance.

--- a/README.md
+++ b/README.md
@@ -91,51 +91,31 @@ $ cat ~/.config/clever-cloud
 
 > Note: this feature is not yet released, but can be previewed from the `master` branch.
 
-You can set extra environment variables on the deployed application by
-prefixing them with `CLEVER_ENV_` in the input arguments:
+You can set extra environment variables on the deployed application under the
+`setEnv` option. It follows the same syntax as .env files (newline-separated,
+key=value).
 
 ```yml
 - uses: 47ng/actions-clever-cloud@master
   with:
-    CLEVER_ENV_FOO: bar         # sets FOO=bar on the application
-    CLEVER_ENV_EGG: spam        # sets EGG=spam on the application
-    extraEnvSafelist: FOO,EGG   # Only allow FOO and EGG to be set
+    setEnv: | # <- note the pipe here..
+      FOO=bar
+      EGG=spam
+    # ^-- ..and the indentation here
   env:
     CLEVER_TOKEN:  ${{ secrets.CLEVER_TOKEN }}
     CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
 ```
 
-Whatever follows `CLEVER_ENV_` will be the name of the environment
-variable in the application, and the value will follow what is passed.
+> _Note: you need to use a [literal block scalar](https://yaml-multiline.info/) `|` to preserve newlines in a YAML string._
 
 Environment variables will be set before the application is deployed,
 to let the new deployment use them.
 
-### Safelisting
-
-Because GitHub actions share their environment, it would be possible for a
-malicious action used before this one to export an undesired `INPUT_CLEVER_ENV_XYZ`
-variable, which would be injected to your application. This is unfortunately
-not a bug, but a feature of Actions, according to GitHub.
-
-> Read more about this issue on my [blog](https://francoisbest.com/posts) post: [The Security of GitHub Actions](https://francoisbest.com/posts/2020/the-security-of-github-actions).
-
-Therefore, to make sure you will only set your own environment variables,
-you must set a safelist of comma-separated environment variable names.
-Only those will make it to your app.
-
-> Note: because the safelist can also be injected, it is strongly recommended
-> to always set it to an empty string for deployments without extra env:
-> ```
-> - uses: 47ng/actions-clever-cloud@master
->   with:
->     extraEnvSafelist: ''   # Disable env injection
->   env:
->     CLEVER_TOKEN:  ${{ secrets.CLEVER_TOKEN }}
->     CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
-> ```
-
 ### Caveats
+
+Multi-line environment variable values (eg: SSH keys, X.509 certificates) are
+currently not supported (due to splitting on newline), but contributions are welcome.
 
 If the deployment fails, the environment variables will still have been
 updated. This could be a problem if your app restarts or scales up, as

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ In your workflow file:
 steps:
   # This action requires an unshallow working copy,
   # so the following prerequisites are necessary:
-  - uses: actions/checkout@v2
+  - uses: actions/checkout@v1.1
   - run: git fetch --prune --unshallow
 
   # Deploy your application
-  - uses: 47ng/actions-clever-cloud@v1
+  - uses: 47ng/actions-clever-cloud@v1.1
     env:
       CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
       CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
@@ -41,7 +41,7 @@ If you have committed the `.clever.json` file, you only need to specify
 the alias of the application to deploy:
 
 ```yml
-- uses: 47ng/actions-clever-cloud@v1
+- uses: 47ng/actions-clever-cloud@v1.1
   with:
     alias: my-app-alias
   env:
@@ -53,7 +53,7 @@ If you don't have this `.clever.json` file or you want to explicly
 deploy to another application, you can pass its ID:
 
 ```yml
-- uses: 47ng/actions-clever-cloud@v1
+- uses: 47ng/actions-clever-cloud@v1.1
   with:
     appID: app_facade42-cafe-babe-cafe-deadf00dbaad
   env:
@@ -88,14 +88,14 @@ $ cat ~/.config/clever-cloud
 
 ## Extra Environment Variables
 
-> Note: this feature is not yet released, but can be previewed from the `master` branch.
+> Support: introduced in v1.1
 
 You can set extra environment variables on the deployed application under the
 `setEnv` option. It follows the same syntax as .env files (newline-separated,
 key=value).
 
 ```yml
-- uses: 47ng/actions-clever-cloud@master
+- uses: 47ng/actions-clever-cloud@v1.1
   with:
     setEnv: | # <- note the pipe here..
       FOO=bar
@@ -125,7 +125,7 @@ set by this action if deployment fails.
 
 ## Deployment Timeout
 
-> Note: this feature is not yet released, but can be previewed from the `master` branch.
+> Support: introduced in v1.1
 
 Because build minutes are precious, and also because of two ongoing issues in
 the Clever Tools CLI (
@@ -135,7 +135,7 @@ you can specify a timeout in seconds after which the workflow will move on,
 regardless of the deployment status:
 
 ```yml
-- uses: 47ng/actions-clever-cloud@master
+- uses: 47ng/actions-clever-cloud@v1.1
   with:
     timeout: 1800 # wait at maximum 30 minutes before moving on
   env:
@@ -148,9 +148,9 @@ regardless of the deployment status:
 This action follows [SemVer](https://semver.org/).
 
 To specify the version of the action to use:
-- `uses: 47ng/actions-clever-cloud@v1`: latest stable version
-- `uses: 47ng/actions-clever-cloud@master`: latest code from master
-- `uses: 47ng/actions-clever-cloud@v1.2.3`: a specific version (check out the [releases](https://github.com/47ng/actions-clever-cloud/releases))
+- `uses: 47ng/actions-clever-cloud@v1.1`: latest stable version
+- `uses: 47ng/actions-clever-cloud@4d9aae3b941dabe7ef59ed94b20f26a63d53d495`: pinned to a specific Git SHA-1 (check out the [releases](https://github.com/47ng/actions-clever-cloud/releases))
+- `uses: 47ng/actions-clever-cloud@master`: latest code from master (not recommended, as it may break: hic sunt dracones.)
 
 ## Why ?
 

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -1,4 +1,4 @@
-import run, { processArguments } from '../src/action'
+import run from '../src/action'
 
 const core = require('@actions/core')
 const { exec } = require('@actions/exec')

--- a/__tests__/processArguments.test.ts
+++ b/__tests__/processArguments.test.ts
@@ -27,29 +27,25 @@ test('obtain auth credentials from the environment', () => {
   expect(args.secret).toEqual('secret')
 })
 
-test('extra env, no safelisting', () => {
-  process.env.INPUT_CLEVER_ENV_FOO = 'foo'
-  process.env.INPUT_CLEVER_ENV_BAR = 'bar'
-  process.env.INPUT_CLEVER_ENV_EVIL = 'evil'
+test('extra env', () => {
+  process.env.INPUT_SETENV = `
+  FOO=foo
+  BAR=bar
+
+  # empty line or comment is ignored
+  lowercase=blah
+  123=456
+  many_equals=dod==d=doodod=d
+`
   process.env.CLEVER_TOKEN = 'token'
   process.env.CLEVER_SECRET = 'secret'
   const args = processArguments()
   expect(args.extraEnv).toBeDefined()
   expect(args.extraEnv!.FOO).toEqual('foo')
   expect(args.extraEnv!.BAR).toEqual('bar')
-  expect(args.extraEnv!.EVIL).toEqual('evil')
-})
-test('extra env, with safelisting', () => {
-  process.env.INPUT_CLEVER_ENV_FOO = 'foo'
-  process.env.INPUT_CLEVER_ENV_BAR = 'bar'
-  process.env.INPUT_CLEVER_ENV_EVIL = 'evil'
-  process.env.INPUT_EXTRAENVSAFELIST = 'FOO,BAR'
-  process.env.CLEVER_TOKEN = 'token'
-  process.env.CLEVER_SECRET = 'secret'
-  const args = processArguments()
-  expect(args.extraEnv).toBeDefined()
-  expect(args.extraEnv!.FOO).toEqual('foo')
-  expect(args.extraEnv!.BAR).toEqual('bar')
+  expect(args.extraEnv!.lowercase).toEqual('blah')
+  expect(args.extraEnv!['123']).toEqual('456')
+  expect(args.extraEnv!.many_equals).toEqual('dod==d=doodod=d')
   expect(args.extraEnv!.EVIL).toBeUndefined()
 })
 

--- a/action.yml
+++ b/action.yml
@@ -36,4 +36,4 @@ inputs:
       to be set, see https://github.com/47ng/ations-clever-cloud#safelisting
 runs:
   using: docker
-  image: docker://47ng/actions-clever-cloud:v2.0.0
+  image: docker://47ng/actions-clever-cloud:v1.1.0

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: Deploy to Clever Cloud
 description: Deploy your application to Clever Cloud
-author: Francois Best
+author: François Best
 branding:
   icon: upload-cloud
   color: red
@@ -15,17 +15,25 @@ inputs:
     description: |
       The ID of your application (can be found in the Clever Cloud console).
       Takes precedence over `alias` if both are defined.
-  extraEnvSafelist:
-    required: false
-    description: |
-      A comma-separated list of extra environment variable names to allow
-      to be set, see https://github.com/47ng/ations-clever-cloud#safelisting
   timeout:
     required: false
     description: |
       How long (in seconds) to wait at most before moving on.
       This can help saving build minutes with very long deployments,
       but you will lose any deployment failure information.
+  setEnv:
+    required: false
+    description: |
+      Extra environment variables to set on the application before deployment.
+      Values are separated by a newline character (\n), use a YAML literal block
+      scalar `|` to preserve newlines and separate multiple variables definitions.
+      (see https://github.com/47ng/actions-clever-cloud#extra-environment-variables)
+  extraEnvSafelist:
+    required: false
+    deprecationMessage: This is no longer needed or used, use the `setEnv` input instead.
+    description: |
+      A comma-separated list of extra environment variable names to allow
+      to be set, see https://github.com/47ng/ations-clever-cloud#safelisting
 runs:
   using: docker
   image: docker://47ng/actions-clever-cloud:latest

--- a/action.yml
+++ b/action.yml
@@ -36,4 +36,4 @@ inputs:
       to be set, see https://github.com/47ng/ations-clever-cloud#safelisting
 runs:
   using: docker
-  image: docker://47ng/actions-clever-cloud:latest
+  image: docker://47ng/actions-clever-cloud:v2.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@47ng/actions-clever-cloud",
-  "version": "0.6.0",
+  "version": "2.0.0",
   "private": true,
   "description": "GitHub Action to deploy to Clever Cloud",
   "main": "dist/main.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@47ng/actions-clever-cloud",
-  "version": "2.0.0",
+  "version": "1.1.0",
   "private": true,
   "description": "GitHub Action to deploy to Clever Cloud",
   "main": "dist/main.js",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "tsc",
     "lint": "eslint src/**/*.ts",
     "test": "jest",
-    "ci": "run-s lint build test"
+    "ci": "run-s lint build test",
+    "prepare": "husky install"
   },
   "repository": {
     "type": "git",
@@ -28,27 +29,27 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@actions/core": "^1.4.0",
+    "@actions/core": "^1.6.0",
     "@actions/exec": "^1.1.0",
-    "clever-tools": "^2.8.0",
-    "ws": "^7.4.5"
+    "clever-tools": "^2.9.1",
+    "ws": "^8.5.0"
   },
   "devDependencies": {
-    "@types/jest": "^26.0.24",
-    "@types/node": "^16.4.9",
-    "@typescript-eslint/parser": "^4.28.5",
+    "@types/jest": "^27.4.1",
+    "@types/node": "^17.0.21",
+    "@typescript-eslint/parser": "^5.13.0",
     "@zeit/ncc": "^0.22.3",
-    "eslint": "^7.32.0",
-    "eslint-plugin-github": "^4.1.5",
-    "eslint-plugin-jest": "^24.4.0",
-    "husky": "^7.0.1",
-    "jest": "^26.6.3",
-    "jest-circus": "^27.0.6",
+    "eslint": "^8.10.0",
+    "eslint-plugin-github": "^4.3.5",
+    "eslint-plugin-jest": "^26.1.1",
+    "husky": "^7.0.4",
+    "jest": "^27.5.1",
+    "jest-circus": "^27.5.1",
     "js-yaml": "^4.1.0",
     "npm-run-all": "^4.1.5",
-    "prettier": "^2.3.2",
-    "ts-jest": "^26.5.6",
-    "typescript": "^4.3.5"
+    "prettier": "^2.5.1",
+    "ts-jest": "^27.1.3",
+    "typescript": "^4.6.2"
   },
   "husky": {
     "hooks": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,12 +1,16 @@
-import run, { processArguments } from './action'
 import core from '@actions/core'
+import run, { processArguments } from './action'
 
 async function main(): Promise<void> {
   try {
     const args = processArguments()
     return await run(args)
   } catch (error) {
-    core.setFailed(error.message)
+    if (error instanceof Error) {
+      core.setFailed(error.message)
+    } else {
+      core.setFailed(String(error))
+    }
   }
 }
 


### PR DESCRIPTION
Extra inputs are now ignored, so the previous trick for setting environment variables no longer works.

Instead, we can use a single input with a multi-line value, where each env var is defined on a line, like a .env file.