### PR TITLE
feat: Add deployPath option for directory-specific deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,3 +255,20 @@ being published, or after a CI run.
 [MIT](https://github.com/47ng/actions-clever-cloud/blob/master/LICENSE) - Made with ❤️ by [François Best](https://francoisbest.com)
 
 Using this action at work ? [Sponsor me](https://github.com/sponsors/franky47) to help with support and maintenance.
+
+## Deploying a Specific Directory
+
+If you want to deploy only a specific directory instead of the entire project, you can use the `deployPath` option:
+
+```yml
+- uses: 47ng/actions-clever-cloud@v2.0.0
+  with:
+    deployPath: ./directory  # Path relative to repository root
+  env:
+    CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
+    CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
+```
+
+This is particularly useful for monorepos or projects where you only want to deploy a subset of your codebase.
+
+Note: The path must be relative to the repository root and must exist.

--- a/README.md
+++ b/README.md
@@ -258,17 +258,29 @@ Using this action at work ? [Sponsor me](https://github.com/sponsors/franky47) t
 
 ## Deploying a Specific Directory
 
-If you want to deploy only a specific directory instead of the entire project, you can use the `deployPath` option:
+> ⚠️ Important note about the difference between `working-directory` and `deployPath`:
+>
+> - `working-directory` (GitHub Actions option) : Only changes the directory where the action runs. All files remain available, only the execution context changes.
+> 
+> - `deployPath` (this action's option) : Specifies exactly which files will be sent to Clever Cloud. Allows deploying only a subset of files, like a `dist` or `build` folder.
+
+### Example
 
 ```yml
+# This will NOT deploy only the build folder:
 - uses: 47ng/actions-clever-cloud@v2.0.0
   with:
-    deployPath: ./directory  # Path relative to repository root
-  env:
-    CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
-    CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
+    working-directory: ./build    # ❌ Only changes where the action runs
+
+# This will deploy only the build folder:
+- uses: 47ng/actions-clever-cloud@v2.0.0
+  with:
+    deployPath: ./build          # ✅ Only sends these files to Clever Cloud
 ```
 
-This is particularly useful for monorepos or projects where you only want to deploy a subset of your codebase.
+This option is particularly useful for:
+- Monorepos where you want to deploy a single package
+- Projects where you only want to deploy built/compiled files
+- Filtering which files are sent to Clever Cloud
 
 Note: The path must be relative to the repository root and must exist.

--- a/__tests__/processArguments.test.ts
+++ b/__tests__/processArguments.test.ts
@@ -136,3 +136,18 @@ test('quiet', () => {
   const args = processArguments()
   expect(args.quiet).toBe(true)
 })
+
+test('deployPath is unset by default', () => {
+  process.env.CLEVER_TOKEN = 'token'
+  process.env.CLEVER_SECRET = 'secret'
+  const args = processArguments()
+  expect(args.deployPath).toBeUndefined()
+})
+
+test('deployPath is set from input', () => {
+  process.env.CLEVER_TOKEN = 'token'
+  process.env.CLEVER_SECRET = 'secret'
+  process.env.INPUT_DEPLOYPATH = './packages/backend'
+  const args = processArguments()
+  expect(args.deployPath).toBe('./packages/backend')
+})

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,11 @@ inputs:
       Values are separated by a newline character (\n), use a YAML literal block
       scalar `|` to preserve newlines and separate multiple variables definitions.
       (see https://github.com/47ng/actions-clever-cloud#extra-environment-variables)
+  deployPath:
+    required: false
+    description: |
+      Specific directory to deploy instead of the entire project.
+      Path must be relative to the repository root.
   logFile:
     required: false
     description: |


### PR DESCRIPTION
# Add deployPath option

This PR adds support for deploying specific directories to Clever Cloud, which is particularly useful for monorepo setups or when only a subset of the codebase needs to be deployed.

## Features

- Added new `deployPath` input option that allows specifying a directory to deploy
- Updated documentation with usage examples and notes
- Directory path must be relative to repository root

## Notes

- The specified path must exist and be relative to the repository root
- This feature is particularly useful for:
  - Monorepo setups
  - Projects where only specific directories need deployment
  - Separating deployment concerns in complex projects