### PR TITLE
fix: timeout units & actually kill the child subprocess

### DIFF
--- a/src/action.test.ts
+++ b/src/action.test.ts
@@ -1,4 +1,6 @@
-import { beforeEach, expect, test, vi } from 'vitest'
+import { EventEmitter } from 'node:events'
+import { PassThrough } from 'node:stream'
+import { afterEach, beforeEach, expect, test, vi } from 'vitest'
 
 // Mock must be defined before imports that use it
 vi.mock('@actions/exec', () => ({
@@ -11,8 +13,14 @@ vi.mock('@actions/core', () => ({
   setFailed: vi.fn()
 }))
 
+// The timeout path spawns the deploy itself so it can kill it on timeout.
+vi.mock('node:child_process', () => ({
+  spawn: vi.fn()
+}))
+
 import { setFailed } from '@actions/core'
 import { exec } from '@actions/exec'
+import { spawn } from 'node:child_process'
 import { run } from './action'
 
 // --
@@ -20,11 +28,36 @@ import { run } from './action'
 const CLEVER_CLI = 'clever-mocked'
 
 const execMock = exec as ReturnType<typeof vi.fn>
+const spawnMock = spawn as ReturnType<typeof vi.fn>
+
+/**
+ * Minimal stand-in for a spawned deploy process: real stdout/stderr streams so
+ * piping works, an EventEmitter for `error`/`close`, and a `kill` spy that
+ * settles the process the way SIGTERM would.
+ */
+function makeFakeChild() {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: PassThrough
+    stderr: PassThrough
+    kill: ReturnType<typeof vi.fn>
+  }
+  child.stdout = new PassThrough()
+  child.stderr = new PassThrough()
+  child.kill = vi.fn(() => {
+    child.emit('close', null)
+    return true
+  })
+  return child
+}
 
 beforeEach(() => {
   vi.clearAllMocks()
   // Reset to default success behavior
   execMock.mockResolvedValue(0)
+})
+
+afterEach(() => {
+  vi.useRealTimers()
 })
 
 // --
@@ -202,15 +235,93 @@ test('deployment failure fails the workflow', async () => {
   expect(setFailed).toHaveBeenCalledWith('Deployment failed with code 42')
 })
 
-test('deployment failure with timeout fails the workflow', async () => {
-  execMock.mockResolvedValue(42)
-  await run({
+test('timeout is interpreted in seconds, not milliseconds', async () => {
+  vi.useFakeTimers()
+  const child = makeFakeChild()
+  spawnMock.mockReturnValue(child)
+  const finished = run({
     token: 'token',
     secret: 'secret',
     cleverCLI: CLEVER_CLI,
-    timeout: 10_000
+    timeout: 1800 // 30 minutes, per action.yml
   })
+  // One millisecond before the 30-minute mark: still waiting.
+  await vi.advanceTimersByTimeAsync(1800 * 1000 - 1)
+  expect(child.kill).not.toHaveBeenCalled()
+  // Crossing 1800s (not 1800ms) is what triggers the timeout.
+  await vi.advanceTimersByTimeAsync(1)
+  expect(child.kill).toHaveBeenCalledWith('SIGTERM')
+  await finished
+})
+
+test('timeout fires: kills the deploy and moves on without failing', async () => {
+  vi.useFakeTimers()
+  const child = makeFakeChild()
+  spawnMock.mockReturnValue(child)
+  const finished = run({
+    token: 'token',
+    secret: 'secret',
+    cleverCLI: CLEVER_CLI,
+    timeout: 1800
+  })
+  await vi.advanceTimersByTimeAsync(1800 * 1000)
+  await finished
+  expect(child.kill).toHaveBeenCalledWith('SIGTERM')
+  expect(setFailed).not.toHaveBeenCalled()
+})
+
+test('deploy completes before timeout: success, no kill', async () => {
+  vi.useFakeTimers()
+  const child = makeFakeChild()
+  spawnMock.mockReturnValue(child)
+  const finished = run({
+    token: 'token',
+    secret: 'secret',
+    cleverCLI: CLEVER_CLI,
+    timeout: 1800
+  })
+  // Let the pre-deploy steps run and the deploy spawn, then succeed.
+  await vi.advanceTimersByTimeAsync(1000)
+  child.emit('close', 0)
+  await finished
+  expect(child.kill).not.toHaveBeenCalled()
+  expect(setFailed).not.toHaveBeenCalled()
+})
+
+test('deploy fails before timeout: fails the workflow', async () => {
+  vi.useFakeTimers()
+  const child = makeFakeChild()
+  spawnMock.mockReturnValue(child)
+  const finished = run({
+    token: 'token',
+    secret: 'secret',
+    cleverCLI: CLEVER_CLI,
+    timeout: 1800
+  })
+  await vi.advanceTimersByTimeAsync(1000)
+  child.emit('close', 42)
+  await finished
+  expect(child.kill).not.toHaveBeenCalled()
   expect(setFailed).toHaveBeenCalledWith('Deployment failed with code 42')
+})
+
+test('spawn error: fails the workflow and leaves no pending timer', async () => {
+  vi.useFakeTimers()
+  const child = makeFakeChild()
+  spawnMock.mockReturnValue(child)
+  const finished = run({
+    token: 'token',
+    secret: 'secret',
+    cleverCLI: CLEVER_CLI,
+    timeout: 1800
+  })
+  await vi.advanceTimersByTimeAsync(1000)
+  child.emit('error', new Error('spawn ENOENT'))
+  await finished
+  expect(setFailed).toHaveBeenCalledWith('spawn ENOENT')
+  // The timeout must be cleared even when the deploy errors out, otherwise the
+  // event loop stays pinned until it fires.
+  expect(vi.getTimerCount()).toBe(0)
 })
 
 test('force deploy application', async () => {

--- a/src/action.ts
+++ b/src/action.ts
@@ -1,8 +1,8 @@
 import * as core from '@actions/core'
 import { exec, type ExecOptions } from '@actions/exec'
+import { spawn } from 'node:child_process'
 import fs from 'node:fs/promises'
 import { PassThrough, Transform, Writable } from 'node:stream'
-import { clearTimeout, setTimeout } from 'node:timers'
 import type { Arguments } from './arguments'
 
 async function checkForShallowCopy(): Promise<void> {
@@ -96,23 +96,40 @@ export async function run({
     }
 
     if (timeout) {
+      // We manage the deploy process ourselves (rather than via @actions/exec)
+      // so we can terminate it when the timeout fires: @actions/exec offers no
+      // cancellation, and a live child process keeps the Node event loop alive,
+      // which would pin the workflow until the deploy finishes anyway.
+      const { child, exited } = spawnDeploy(cleverCLI, args, execOptions)
       let timeoutID: NodeJS.Timeout | undefined
       let timedOut = false
       const timeoutPromise = new Promise<void>(resolve => {
+        // `timeout` is expressed in seconds (see action.yml), setTimeout is in ms.
         timeoutID = setTimeout(() => {
           timedOut = true
           resolve()
-        }, timeout)
+        }, timeout * 1000)
       })
-      const result = await Promise.race([
-        exec(cleverCLI, args, execOptions),
-        timeoutPromise
-      ])
-      if (timeoutID) {
-        clearTimeout(timeoutID)
+      let result: number | void
+      try {
+        result = await Promise.race([exited, timeoutPromise])
+      } finally {
+        // Always clear the timer, even if `exited` rejects (e.g. spawn error),
+        // otherwise the pending timeout keeps the event loop alive until it fires.
+        if (timeoutID) {
+          clearTimeout(timeoutID)
+        }
       }
       if (timedOut) {
+        // Stop waiting and let the workflow move on. Killing the child releases
+        // the event loop so the action can exit promptly (the documented
+        // tradeoff: we lose any deployment failure information).
+        child.kill('SIGTERM')
+        // The killed process settles `exited` later; swallow it so it doesn't
+        // surface as an unhandled rejection after we've moved on.
+        exited.catch(() => {})
         core.info('Deployment timed out, moving on with workflow run')
+        return
       }
       core.info(`result: ${result}`)
       if (typeof result === 'number' && result !== 0) {
@@ -135,6 +152,35 @@ export async function run({
 }
 
 // --
+
+/**
+ * Spawn the Clever CLI deploy ourselves so we keep a handle on the child
+ * process and can terminate it when the deployment timeout fires.
+ *
+ * Output is piped into the same tee stream used by @actions/exec (via
+ * `options.outStream`) so console logging, log files and annotation injection
+ * keep working identically to the non-timeout path.
+ */
+function spawnDeploy(
+  cleverCLI: string,
+  args: string[],
+  options: ExecOptions
+): { child: ReturnType<typeof spawn>; exited: Promise<number> } {
+  const child = spawn(cleverCLI, args, {
+    cwd: options.cwd,
+    stdio: ['ignore', 'pipe', 'pipe']
+  })
+  if (options.outStream) {
+    // `end: false` keeps the shared tee open when either stream closes.
+    child.stdout.pipe(options.outStream, { end: false })
+    child.stderr.pipe(options.outStream, { end: false })
+  }
+  const exited = new Promise<number>((resolve, reject) => {
+    child.once('error', reject)
+    child.once('close', code => resolve(code ?? 0))
+  })
+  return { child, exited }
+}
 
 async function getOutputStream(
   quiet: boolean,


### PR DESCRIPTION
## Tasks

- [x] Try it out on an infinite loop deployment -> deployment keeps looping infinitely until stopped on the Clever Console, but the workflow run step moves on after time out.

Follow-up PR: add an output to know the outcome of the step (success, timeout, failed).

Closes #226.