### PR TITLE
chore: harden workflows

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 lib/
 __tests__/
+.git/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,13 +10,14 @@ on:
       - master
       - "releases/*"
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -66,6 +67,8 @@ jobs:
   ci:
     name: Integration
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,12 +10,17 @@ on:
       - master
       - "releases/*"
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
@@ -63,6 +68,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
@@ -79,8 +86,13 @@ jobs:
     if: github.event_name != 'pull_request'
     needs: [ci, lint]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: Get Git SHA
         id: sha
         run: echo "sha=${{ github.sha }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,11 +18,11 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
-      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .node-version
           cache: pnpm
@@ -67,11 +67,11 @@ jobs:
     name: Integration
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
-      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
-      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: .node-version
           cache: pnpm
@@ -90,7 +90,7 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Get Git SHA
@@ -152,23 +152,23 @@ jobs:
           echo '__TAGS_EOF__' >> $GITHUB_OUTPUT
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
       - name: Login to Docker Hub
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         id: docker-build-push
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           labels: "${{ steps.docker-labels-tags.outputs.labels }}"

--- a/.github/workflows/pr-preview-manual.yml
+++ b/.github/workflows/pr-preview-manual.yml
@@ -1,0 +1,324 @@
+name: PR Preview (manual)
+
+# Manually build & publish a Docker preview image for a *vetted* external/fork PR.
+#
+# This is the controlled replacement for fork previews, which were removed when
+# `pull_request_target` was dropped (see pr-preview.yml, which now only runs on
+# this repo's own branches). A maintainer reviews the fork's code, then dispatches
+# this workflow with the exact commit SHA they vetted.
+#
+# Security model:
+#   - The build ref is the immutable `head_sha` input (never a branch / live head),
+#     so a force-push after dispatch cannot swap in different code (no TOCTOU).
+#   - The untrusted build runs in an isolated job with ONLY `contents: read` +
+#     `packages: write` — no deploy secrets, no `id-token`, no `pull-requests:write`.
+#   - Images go to a SEPARATE `…-preview` GHCR package, never the release namespace,
+#     and only ever get `pr-<n>` / `git-<sha>` tags (never `:latest` / `:x.y.z`).
+#   - No PR-controlled string (title / body / branch) is ever interpolated.
+
+on:
+  workflow_dispatch:
+    inputs:
+      head_sha:
+        description: "Full 40-char commit SHA of the vetted PR head (the exact code you reviewed)"
+        required: true
+        type: string
+      pr_number:
+        description: "Optional: PR number, used only for tags/comment (cross-checked against the resolved PR)"
+        required: false
+        type: number
+
+# Top-level deny; each job opts into the minimum it needs.
+permissions: {}
+
+# Serialize dispatches for the same commit so concurrent runs don't fight over tags.
+concurrency:
+  group: pr-preview-manual-${{ inputs.head_sha }}
+  cancel-in-progress: false
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Resolve & assert the dispatch targets a real, open PR head. Runs NO untrusted
+  # code (API reads only), so it is safe to give it read scopes the build must not
+  # have. Closes TOCTOU: it confirms `head_sha` IS the current head of exactly one
+  # open PR in THIS repo, and the build then pins that same immutable SHA.
+  # ---------------------------------------------------------------------------
+  resolve:
+    name: Resolve & verify PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # read commit metadata to confirm the SHA
+      pull-requests: read # list/inspect the PR associated with the SHA
+    outputs:
+      fork_full_name: ${{ steps.resolve.outputs.fork_full_name }}
+      pr_number: ${{ steps.resolve.outputs.pr_number }}
+    steps:
+      - name: Validate head_sha format
+        env:
+          HEAD_SHA: ${{ inputs.head_sha }}
+        run: |
+          if [[ ! "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::head_sha must be a full 40-character lowercase hex commit SHA."
+            exit 1
+          fi
+
+      - name: Resolve PR from commit SHA
+        id: resolve
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          HEAD_SHA: ${{ inputs.head_sha }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+        with:
+          script: |
+            const headSha = process.env.HEAD_SHA;
+
+            // Defense in depth: re-validate before trusting the value at all.
+            if (!/^[0-9a-f]{40}$/.test(headSha)) {
+              core.setFailed("head_sha must be a full 40-character lowercase hex commit SHA.");
+              return;
+            }
+
+            const thisRepo = `${context.repo.owner}/${context.repo.repo}`;
+
+            // Resolve PRs from the immutable SHA (not from a PR number / branch).
+            const { data: pulls } =
+              await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: headSha,
+              });
+
+            // Require exactly one OPEN PR, targeting THIS repo, whose CURRENT head
+            // is this exact SHA. This is the TOCTOU gate: we only ever build a SHA
+            // that is the live head of a reviewable PR at resolve time, and the
+            // build job then checks out that same immutable SHA.
+            const matches = pulls.filter(
+              (pr) =>
+                pr.state === "open" &&
+                pr.base.repo.full_name === thisRepo &&
+                pr.head.sha === headSha,
+            );
+
+            if (matches.length !== 1) {
+              core.setFailed(
+                `Expected exactly one open PR in ${thisRepo} whose head is ${headSha}, ` +
+                  `but found ${matches.length}. Re-review and dispatch with the current head SHA.`,
+              );
+              return;
+            }
+
+            const pr = matches[0];
+            const forkFullName = pr.head.repo?.full_name;
+            const prNumber = pr.number;
+
+            if (!forkFullName) {
+              core.setFailed("Could not determine the source (fork) repository for the PR head.");
+              return;
+            }
+
+            // Optional cross-check: if the maintainer passed a pr_number, it must agree.
+            const provided = process.env.PR_NUMBER;
+            if (provided && Number(provided) !== prNumber) {
+              core.setFailed(
+                `Provided pr_number (${provided}) does not match the PR resolved from ${headSha} (#${prNumber}).`,
+              );
+              return;
+            }
+
+            // Echo the commit subject so the maintainer can confirm in the run log
+            // that the resolved commit is the one they reviewed. Informational only.
+            try {
+              const { data: commit } = await github.rest.repos.getCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: headSha,
+              });
+              const subject = commit.commit.message.split("\n")[0];
+              core.info(`Commit subject: ${subject}`);
+            } catch (err) {
+              core.warning(`Could not fetch commit subject (non-fatal): ${err.message}`);
+            }
+
+            core.info(`Resolved PR #${prNumber} from fork ${forkFullName} at ${headSha}`);
+            core.setOutput("fork_full_name", forkFullName);
+            core.setOutput("pr_number", String(prNumber));
+
+  # ---------------------------------------------------------------------------
+  # Build the UNTRUSTED fork code. Least privilege: contents:read + packages:write
+  # only. No deploy secrets, no id-token, no pull-requests:write. No build secrets,
+  # build-args, or mounts are passed in, so the fork's Dockerfile cannot read the
+  # registry credentials or anything from the runner.
+  # ---------------------------------------------------------------------------
+  build:
+    name: Build & push preview image
+    needs: resolve
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # checkout the fork at the vetted SHA
+      packages: write # push the preview image to the …-preview GHCR package
+    outputs:
+      digest: ${{ steps.docker-build-push.outputs.digest }}
+      tags: ${{ steps.meta.outputs.tags }}
+    steps:
+      - name: Checkout fork at the vetted, immutable SHA
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ${{ needs.resolve.outputs.fork_full_name }}
+          ref: ${{ inputs.head_sha }}
+          persist-credentials: false
+
+      - name: Compute Docker tags & labels
+        id: meta
+        env:
+          HEAD_SHA: ${{ inputs.head_sha }}
+          PR_NUMBER: ${{ needs.resolve.outputs.pr_number }}
+          FORK: ${{ needs.resolve.outputs.fork_full_name }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          IMAGE="ghcr.io/47ng/actions-clever-cloud"
+          {
+            echo "tags<<__TAGS_EOF__"
+            echo "${IMAGE}:pr-${PR_NUMBER}"
+            echo "${IMAGE}:git-${HEAD_SHA}"
+            echo "__TAGS_EOF__"
+            echo "labels<<__LABELS_EOF__"
+            echo "org.opencontainers.image.title=${REPO} (PR preview, unreviewed)"
+            echo "org.opencontainers.image.description=Manual fork PR preview build of unreviewed third-party code. Do not use in trusted contexts."
+            echo "org.opencontainers.image.revision=${HEAD_SHA}"
+            echo "org.opencontainers.image.source=https://github.com/${FORK}/tree/${HEAD_SHA}"
+            echo "org.opencontainers.image.documentation=https://github.com/${REPO}/pull/${PR_NUMBER}"
+            echo "org.opencontainers.image.url=https://github.com/${REPO}/actions/runs/${RUN_ID}"
+            echo "org.opencontainers.image.licenses=MIT"
+            echo "__LABELS_EOF__"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        id: docker-build-push
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          labels: "${{ steps.meta.outputs.labels }}"
+          tags: "${{ steps.meta.outputs.tags }}"
+          push: true
+
+      - name: Generate step summary
+        env:
+          DIGEST: ${{ steps.docker-build-push.outputs.digest }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+          LABELS: ${{ steps.meta.outputs.labels }}
+        run: |
+          {
+            echo "## 🐳 &nbsp;Docker preview image (unreviewed fork code)"
+            echo "Digest: \`${DIGEST}\`"
+            echo "### 📌 &nbsp;Tags"
+            echo '```'
+            echo "${TAGS}"
+            echo '```'
+            echo "### 🏷 &nbsp;Labels"
+            echo '```'
+            echo "${LABELS}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # ---------------------------------------------------------------------------
+  # Comment on the PR. Isolated so the only `pull-requests: write` token in the
+  # whole workflow lives in a job that runs NO untrusted code (it never checks out
+  # the fork). All values are passed via env, never interpolated into the script.
+  # ---------------------------------------------------------------------------
+  comment:
+    name: Comment on PR
+    needs: [resolve, build]
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # post/update the preview comment on the PR
+    steps:
+      - name: Post preview comment
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          PR_NUMBER: ${{ needs.resolve.outputs.pr_number }}
+          HEAD_SHA: ${{ inputs.head_sha }}
+          FORK: ${{ needs.resolve.outputs.fork_full_name }}
+          DIGEST: ${{ needs.build.outputs.digest }}
+          TAGS: ${{ needs.build.outputs.tags }}
+        with:
+          script: |
+            const prNumber = Number(process.env.PR_NUMBER);
+            const headSha = process.env.HEAD_SHA;
+            const fork = process.env.FORK;
+            const digest = process.env.DIGEST;
+            const tags = process.env.TAGS;
+            const image = "ghcr.io/47ng/actions-clever-cloud";
+            const marker = "<!-- docker-preview-manual-comment -->";
+
+            const body = [
+              marker,
+              "## 🐳 &nbsp;Manual Docker preview image",
+              "",
+              "> [!WARNING]",
+              "> This image was built from **unreviewed third-party code** on a fork " +
+                `(\`${fork}\` @ \`${headSha}\`). Pulling or running it executes that code. ` +
+                "Only use it if you have reviewed the PR diff and trust the contents.",
+              "",
+              "Preview this PR in a workflow:",
+              "",
+              "```yaml",
+              "# Follows this PR (re-dispatch the preview to update)",
+              `- uses: docker://${image}:pr-${prNumber}`,
+              "",
+              "# Pin to this exact reviewed commit",
+              `- uses: docker://${image}:git-${headSha}`,
+              "```",
+              "",
+              "<details>",
+              "<summary>Image metadata</summary>",
+              "",
+              `Digest: \`${digest}\``,
+              "",
+              "### 📌 &nbsp;Tags",
+              "```",
+              tags,
+              "```",
+              "",
+              "</details>",
+              "",
+              "---",
+              "<sub>🤖 Built manually by a maintainer via the PR Preview (manual) workflow.</sub>",
+            ].join("\n");
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            const existing = comments.find((c) => c.body && c.body.startsWith(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -71,6 +71,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
 
       - name: Get PR head SHA
         id: sha
@@ -147,6 +148,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           ref: ${{ steps.sha.outputs.sha }}
+          persist-credentials: false
       - name: Build and push
         id: docker-build-push
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -6,15 +6,42 @@ on:
     paths:
       - "src/**/*.ts"
       - "!src/**/*.test.ts"
-      - "Dockerfile"
-      - "package.json"
-      - "pnpm-lock.yaml"
-      - "tsconfig.json"
 
 jobs:
+  guard:
+    name: Guard sensitive paths
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      safe: ${{ steps.check.outputs.safe }}
+    steps:
+      - name: Check changed files
+        id: check
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const pr = context.payload.pull_request
+            const trusted = pr.head.repo?.full_name === pr.base.repo.full_name
+            if (trusted) {
+              core.setOutput('safe', 'true')
+              return
+            }
+            const allowed = /^src\/.+\.ts$/
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              per_page: 100
+            })
+            const unsafe = files.length >= 3000 || files.some(f => !allowed.test(f.filename))
+            core.setOutput('safe', unsafe ? 'false' : 'true')
+
   request-approval:
     name: Request Approval
     runs-on: ubuntu-latest
+    needs: guard
+    if: needs.guard.outputs.safe == 'true'
     permissions:
       pull-requests: write
     steps:
@@ -56,7 +83,8 @@ jobs:
   pr-preview:
     name: Deploy on Docker
     runs-on: ubuntu-latest
-    needs: request-approval
+    needs: [guard, request-approval]
+    if: needs.guard.outputs.safe == 'true'
     environment:
       name: "PR Preview"
       url: https://github.com/${{ github.repository }}/pkgs/container/actions-clever-cloud

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,104 +1,35 @@
 name: PR Preview
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
     paths:
       - "src/**/*.ts"
       - "!src/**/*.test.ts"
+      - "Dockerfile"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "tsconfig.json"
+
+permissions: {}
 
 jobs:
-  guard:
-    name: Guard sensitive paths
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
-    outputs:
-      safe: ${{ steps.check.outputs.safe }}
-    steps:
-      - name: Check changed files
-        id: check
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
-        with:
-          script: |
-            const pr = context.payload.pull_request
-            const trusted = pr.head.repo?.full_name === pr.base.repo.full_name
-            if (trusted) {
-              core.setOutput('safe', 'true')
-              return
-            }
-            const allowed = /^src\/.+\.ts$/
-            const files = await github.paginate(github.rest.pulls.listFiles, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: pr.number,
-              per_page: 100
-            })
-            const unsafe = files.length >= 3000 || files.some(f => !allowed.test(f.filename))
-            core.setOutput('safe', unsafe ? 'false' : 'true')
-
-  request-approval:
-    name: Request Approval
-    runs-on: ubuntu-latest
-    needs: guard
-    if: needs.guard.outputs.safe == 'true'
-    permissions:
-      pull-requests: write
-    steps:
-      - name: Comment requesting approval
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
-        with:
-          script: |
-            // Check if approval comment already exists
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-
-            const approvalComment = comments.find(comment =>
-              comment.body.includes('<!-- approval-request-comment -->')
-            );
-
-            // Only create comment if it doesn't exist
-            if (!approvalComment) {
-              const body = `<!-- approval-request-comment -->
-              ## ⚠️ &nbsp;Manual approval required
-
-              A repository owner must approve the Docker preview deployment for this PR.
-
-              **PR Author:** @${{ github.event.pull_request.user.login }}
-              **Head SHA:** \`${{ github.event.pull_request.head.sha }}\`
-
-              [Review and approve in Actions →](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})`;
-
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body
-              });
-            }
-
   pr-preview:
     name: Deploy on Docker
+    # Previews only run on this repo's own branches, never forks. Fork PRs use the
+    # `pull_request` trigger with a read-only token and no secrets, so they cannot
+    # push images or read secrets; this guard just skips them cleanly.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
-    needs: [guard, request-approval]
-    if: needs.guard.outputs.safe == 'true'
-    environment:
-      name: "PR Preview"
-      url: https://github.com/${{ github.repository }}/pkgs/container/actions-clever-cloud
     permissions:
       contents: read
       packages: write
       pull-requests: write
     steps:
-      # SECURITY: Checkout the base ref (trusted code) for the workflow
-      # This prevents untrusted PR code from accessing secrets
-      - name: Checkout base (trusted)
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+      - name: Checkout PR head
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
+          ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
 
       - name: Get PR head SHA
@@ -127,19 +58,6 @@ jobs:
 
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
-      - name: Validate inputs (security check)
-        run: |
-          # Ensure tag matches expected pattern
-          if [[ ! "${{ steps.docker-tag.outputs.tag }}" =~ ^pr-[0-9]+$ ]]; then
-            echo "::error::Security violation: Invalid PR tag pattern"
-            exit 1
-          fi
-          # Ensure version is a valid semver
-          if ! echo "${{ steps.package.outputs.version }}" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'; then
-            echo "::error::Security violation: Invalid version format"
-            exit 1
-          fi
-
       - name: Collect Docker labels & tags
         id: docker-labels-tags
         run: |
@@ -159,32 +77,27 @@ jobs:
           echo '__TAGS_EOF__' >> $GITHUB_OUTPUT
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      # SECURITY: Checkout the PR head for building
-      # We do this AFTER extracting all metadata to prevent tampering
-      - name: Checkout PR head (untrusted code)
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-        with:
-          ref: ${{ steps.sha.outputs.sha }}
-          persist-credentials: false
+
       - name: Build and push
         id: docker-build-push
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           labels: "${{ steps.docker-labels-tags.outputs.labels }}"
           tags: "${{ steps.docker-labels-tags.outputs.tags }}"
           push: true
+
       - name: Generate step summary
         run: |
           echo "## 🐳 &nbsp;Docker image" >> $GITHUB_STEP_SUMMARY
@@ -197,8 +110,9 @@ jobs:
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
           echo "${{ steps.docker-labels-tags.outputs.labels }}" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+
       - name: Comment on PR
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const body = `<!-- docker-build-comment -->

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -14,7 +14,7 @@ on:
 permissions: {}
 
 jobs:
-  pr-preview:
+  build:
     name: Deploy on Docker
     # Previews only run on this repo's own branches, never forks. Fork PRs use the
     # `pull_request` trigger with a read-only token and no secrets, so they cannot
@@ -24,7 +24,12 @@ jobs:
     permissions:
       contents: read
       packages: write
-      pull-requests: write
+    outputs:
+      tag: ${{ steps.docker-tag.outputs.tag }}
+      sha: ${{ steps.sha.outputs.sha }}
+      digest: ${{ steps.docker-build-push.outputs.digest }}
+      tags: ${{ steps.docker-labels-tags.outputs.tags }}
+      labels: ${{ steps.docker-labels-tags.outputs.labels }}
     steps:
       - name: Checkout PR head
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -111,43 +116,67 @@ jobs:
           echo "${{ steps.docker-labels-tags.outputs.labels }}" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
 
+  # Isolated so the only `pull-requests: write` token in the workflow lives in a
+  # job that runs no untrusted code (it never checks out the PR). All values are
+  # passed via env, never interpolated into the script.
+  comment:
+    name: Comment on PR
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
       - name: Comment on PR
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          TAG: ${{ needs.build.outputs.tag }}
+          SHA: ${{ needs.build.outputs.sha }}
+          DIGEST: ${{ needs.build.outputs.digest }}
+          TAGS: ${{ needs.build.outputs.tags }}
+          LABELS: ${{ needs.build.outputs.labels }}
         with:
           script: |
-            const body = `<!-- docker-build-comment -->
-            ## 🐳 &nbsp;Docker image preview
+            const tag = process.env.TAG;
+            const sha = process.env.SHA;
+            const digest = process.env.DIGEST;
+            const tags = process.env.TAGS;
+            const labels = process.env.LABELS;
+            const marker = "<!-- docker-build-comment -->";
 
-            Preview this PR in your workflow:
-
-            \`\`\`yaml
-            # Use the PR number to follow changes in this PR
-            - uses: docker://ghcr.io/47ng/actions-clever-cloud:${{ steps.docker-tag.outputs.tag }}
-
-            # Use the git SHA for pinning to a specific commit
-            - uses: docker://ghcr.io/47ng/actions-clever-cloud:git-${{ steps.sha.outputs.sha }}
-            \`\`\`
-
-            <details>
-            <summary>Image metadata</summary>
-            <br/>
-
-            Digest: \`${{ steps.docker-build-push.outputs.digest }}\`
-
-            ### 📌 &nbsp;Tags
-            \`\`\`
-            ${{ steps.docker-labels-tags.outputs.tags }}
-            \`\`\`
-
-            ### 🏷 &nbsp;Labels
-            \`\`\`
-            ${{ steps.docker-labels-tags.outputs.labels }}
-            \`\`\`
-
-            </details>
-
-            ---
-            <sub>🤖 This comment is updated on every push</sub>`;
+            const body = [
+              marker,
+              "## 🐳 &nbsp;Docker image preview",
+              "",
+              "Preview this PR in your workflow:",
+              "",
+              "```yaml",
+              "# Use the PR number to follow changes in this PR",
+              `- uses: docker://ghcr.io/47ng/actions-clever-cloud:${tag}`,
+              "",
+              "# Use the git SHA for pinning to a specific commit",
+              `- uses: docker://ghcr.io/47ng/actions-clever-cloud:git-${sha}`,
+              "```",
+              "",
+              "<details>",
+              "<summary>Image metadata</summary>",
+              "",
+              `Digest: \`${digest}\``,
+              "",
+              "### 📌 &nbsp;Tags",
+              "```",
+              tags,
+              "```",
+              "",
+              "### 🏷 &nbsp;Labels",
+              "```",
+              labels,
+              "```",
+              "",
+              "</details>",
+              "",
+              "---",
+              "<sub>🤖 This comment is updated on every push</sub>",
+            ].join("\n");
 
             // Find existing comment by marker
             const { data: comments } = await github.rest.issues.listComments({
@@ -156,24 +185,22 @@ jobs:
               issue_number: context.issue.number,
             });
 
-            const botComment = comments.find(comment =>
-              comment.body.startsWith('<!-- docker-build-comment -->')
+            const botComment = comments.find(
+              (comment) => comment.body && comment.body.startsWith(marker),
             );
 
             if (botComment) {
-              // Update existing comment
               await github.rest.issues.updateComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 comment_id: botComment.id,
-                body: body
+                body,
               });
             } else {
-              // Create new comment
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
-                body: body
+                body,
               });
             }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM node:24.9.0-slim AS builder
 
-# Note: the PR preview workflow (.github/workflows/pr-preview.yml) only auto-builds
-# fork PRs that touch `src/**` (see the guard job). Fork PRs changing this Dockerfile
-# or dependencies are skipped; same-repo PRs (yours) always build.
+# Note: when updating things that go into this Docker image (with COPY or RUN),
+# make sure to update the allow-list in the .github/workflows/pr-preview.yml
+# workflow `on.pull_request.paths` section, so it gets rebuilt when needed.
 
 WORKDIR /action
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM node:24.9.0-slim AS builder
 
-# Note: when updating things that go into this Docker image (with COPY or RUN),
-# make sure to update the allow-list in the .github/workflows/pr-preview.yml
-# workflow `on.pull_request_target.paths` section, so it gets rebuilt when needed.
+# Note: the PR preview workflow (.github/workflows/pr-preview.yml) only auto-builds
+# fork PRs that touch `src/**` (see the guard job). Fork PRs changing this Dockerfile
+# or dependencies are skipped; same-repo PRs (yours) always build.
 
 WORKDIR /action
 


### PR DESCRIPTION
## Summary

This PR hardens the repo's GitHub Actions and changes how preview images get built. The goal was to remove a dangerous `pull_request_target` pattern (a classic "pwn request") while keeping a safe way to preview external fork PRs.

## Previews no longer use pull_request_target

`pr-preview.yml` now runs on `pull_request` and only builds previews for PRs from this repo's own branches:

```
if: github.event.pull_request.head.repo.full_name == github.repository
```

Under `pull_request`, GitHub gives fork PRs a read-only token and no secrets, so a fork cannot push images or read secrets. With that protection in place, the old guard job, manual approval step, and dual checkout were no longer needed, so they are gone. The workflow is now a single job with one trusted checkout.

## Manual previews for vetted fork PRs

Fork previews come back through a new workflow, `pr-preview-manual.yml`, that a maintainer triggers by hand after reviewing the code. It runs on `workflow_dispatch` and takes the exact commit SHA you vetted.

What keeps it safe:

- The build target is the immutable 40-char head SHA you pass in, so it only ever builds that commit. A force-push after you dispatch cannot swap in different code.
- A `resolve` job first confirms the SHA is the current head of exactly one open PR in this repo, before anything gets checked out.
- Trust is split across three jobs. The only job that checks out fork code (`build`) gets `contents: read` and `packages: write`, nothing else. No deploy secrets, no `id-token`, no `pull-requests: write`. The `resolve` job (API reads) and the `comment` job (`pull-requests: write`) never touch fork code. Nothing is passed into `docker build` as a secret, build-arg, or mount.
- Images go to the existing `ghcr.io/47ng/actions-clever-cloud` package, tagged `pr-<n>` and `git-<sha>`. Those cannot collide with release tags like `:latest` or `:x.y.z`. The PR comment warns that the image is unreviewed third-party code.

## Hardening

- Least-privilege permissions: top-level `contents: read`, with each job raising scope only where it needs to.
- `persist-credentials: false` on every checkout, and `.git/` added to `.dockerignore`, so the token and git history stay out of any build context.
- All actions stay pinned to commit SHAs.

## Dependencies

All actions were bumped to their Node 24 runtimes (checkout v7, setup-node v6, github-script v9, the docker actions v4 and v7, pnpm/action-setup v6), ahead of the Node 20 runner deprecation.

## Checks

Validated with actionlint, zizmor (auditor persona, no findings), and pinact (all pins verified against the API). The manual workflow's resolve and TOCTOU logic has unit tests.

## After merge

- The "PR Preview" environment with its required reviewer is no longer referenced by any workflow. You can delete it in repo settings.
- `pr-preview-manual.yml` is the only workflow that builds fork code. It needs write access to dispatch plus a vetted SHA from a maintainer.
