### PR TITLE
chore: release v2.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ steps:
       fetch-depth: 0
 
   # Deploy your application
-  - uses: 47ng/actions-clever-cloud@v2.1.0
+  - uses: 47ng/actions-clever-cloud@v2.1.1
     env:
       CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
       CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
@@ -60,7 +60,7 @@ If you have committed the `.clever.json` file, you only need to specify
 the alias of the application to deploy:
 
 ```yml
-- uses: 47ng/actions-clever-cloud@v2.1.0
+- uses: 47ng/actions-clever-cloud@v2.1.1
   with:
     alias: my-app-alias
   env:
@@ -72,7 +72,7 @@ If you don't have this `.clever.json` file or you want to explicly
 deploy to another application, you can pass its ID:
 
 ```yml
-- uses: 47ng/actions-clever-cloud@v2.1.0
+- uses: 47ng/actions-clever-cloud@v2.1.1
   with:
     appID: app_facade42-cafe-babe-cafe-deadf00dbaad
   env:
@@ -115,7 +115,7 @@ You can set extra environment variables on the deployed application under the
 key=value).
 
 ```yml
-- uses: 47ng/actions-clever-cloud@v2.1.0
+- uses: 47ng/actions-clever-cloud@v2.1.1
   with:
     setEnv: | # <- note the pipe here..
       FOO=bar
@@ -155,7 +155,7 @@ you can specify a timeout in seconds after which the workflow will move on,
 regardless of the deployment status:
 
 ```yml
-- uses: 47ng/actions-clever-cloud@v2.1.0
+- uses: 47ng/actions-clever-cloud@v2.1.1
   with:
     timeout: 1800 # wait at maximum 30 minutes before moving on
   env:
@@ -170,7 +170,7 @@ regardless of the deployment status:
 Clever Cloud uses a Git remote to perform deploys. By default, if the commit you want to deploy is not a fast-forward from the commit currently deployed, the deploy will be rejected. You can pass `force: true` to force the deploy anyway:
 
 ```yml
-- uses: 47ng/actions-clever-cloud@v2.1.0
+- uses: 47ng/actions-clever-cloud@v2.1.1
   with:
     appID: app_facade42-cafe-babe-cafe-deadf00dbaad
     force: true
@@ -191,7 +191,7 @@ When the local and remote commits are identical, you can control what happens us
 - `rebuild`: Rebuild and redeploy the application
 
 ```yml
-- uses: 47ng/actions-clever-cloud@v2.1.0
+- uses: 47ng/actions-clever-cloud@v2.1.1
   with:
     sameCommitPolicy: restart
   env:
@@ -206,7 +206,7 @@ When the local and remote commits are identical, you can control what happens us
 You can write the deployment logs to a file for archiving:
 
 ```yml
-- uses: 47ng/actions-clever-cloud@v2.1.0
+- uses: 47ng/actions-clever-cloud@v2.1.1
   with:
     logFile: ./clever-cloud-deploy.log
   env:
@@ -225,7 +225,7 @@ If your deployment process is susceptible to log secrets or PII, you can also
 disable it from printing onto the console, using the `quiet` option:
 
 ```yml
-- uses: 47ng/actions-clever-cloud@v2.1.0
+- uses: 47ng/actions-clever-cloud@v2.1.1
   with:
     quiet: true
   env:
@@ -247,7 +247,7 @@ This action follows [SemVer](https://semver.org/).
 
 To specify the version of the action to use:
 
-- `uses: 47ng/actions-clever-cloud@v2.1.0`: latest stable version
+- `uses: 47ng/actions-clever-cloud@v2.1.1`: latest stable version
 - `uses: 47ng/actions-clever-cloud@f496297399b2351f4459d10f556e1c4eff2566b7`: pinned to a specific Git SHA-1 (check out the [releases](https://github.com/47ng/actions-clever-cloud/releases))
 - `uses: docker://ghcr.io/47ng/actions-clever-cloud:latest`: latest code from master (not recommended, as it may break: hic sunt dracones.)
 
@@ -291,12 +291,12 @@ Using this action at work ? [Sponsor me](https://github.com/sponsors/franky47) t
 
 ```yml
 # This will NOT deploy only the build folder:
-- uses: 47ng/actions-clever-cloud@v2.1.0
+- uses: 47ng/actions-clever-cloud@v2.1.1
   with:
     working-directory: ./build # ❌ Only changes where the action runs
 
 # This will deploy only the build folder:
-- uses: 47ng/actions-clever-cloud@v2.1.0
+- uses: 47ng/actions-clever-cloud@v2.1.1
   with:
     deployPath: ./build # ✅ Only sends these files to Clever Cloud
 ```

--- a/action.yml
+++ b/action.yml
@@ -56,4 +56,4 @@ inputs:
       If not set, the Clever Cloud CLI default (error) will be used.
 runs:
   using: docker
-  image: docker://ghcr.io/47ng/actions-clever-cloud:2.1.0
+  image: docker://ghcr.io/47ng/actions-clever-cloud:2.1.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@47ng/actions-clever-cloud",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "private": true,
   "description": "GitHub Action to deploy to Clever Cloud",
   "license": "MIT",


### PR DESCRIPTION
Cuts v2.1.1, a patch release bundling everything that landed on master since v2.1.0.

The headline is the timeout fix (#227): timeouts were interpreted in the wrong units and the child deployment subprocess was left running after a timeout. This release also carries the dependency refresh (#230) and workflow hardening (#228).

Bumps `package.json` and the `action.yml` Docker image tag in lockstep so the version-consistency check passes, and points the README examples at `@v2.1.1`. Merging to master builds and pushes the `2.1.1` image, after which the GitHub release can be tagged.
