### PR TITLE
fix: credential hygiene, truthful deployPath docs, robust log pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,8 @@ regardless of the deployment status:
 ## Force deployement
 
 > Support: introduced in v1.2.0
-> <
-> Clever Cloud uses a Git remote to perform deploys. By default, if the commit you want to deploy is not a fast-forward from the commit currently deployed, the deploy will be rejected. You can pass `force: true` to force the deploy anyway:
+
+Clever Cloud uses a Git remote to perform deploys. By default, if the commit you want to deploy is not a fast-forward from the commit currently deployed, the deploy will be rejected. You can pass `force: true` to force the deploy anyway:
 
 ```yml
 - uses: 47ng/actions-clever-cloud@v2.1.1

--- a/README.md
+++ b/README.md
@@ -278,33 +278,36 @@ being published, or after a CI run.
 
 Using this action at work ? [Sponsor me](https://github.com/sponsors/franky47) to help with support and maintenance.
 
-## Deploying a Specific Directory
+## Running the Clever CLI From a Specific Directory
 
 > Support: introduced in v2.1.0
 
-> ⚠️ Important note about the difference between `working-directory` and `deployPath`:
+> ⚠️ `deployPath` changes the CLI's working directory only. It does NOT
+> restrict which files get deployed: `clever deploy` always pushes the git
+> HEAD of the repository containing that directory. The Clever CLI locates
+> the repository by walking up from the working directory until it finds a
+> `.git` folder, so a subdirectory of a normal checkout resolves back to the
+> repository root and the entire repository is deployed regardless of this
+> setting.
 >
-> - `working-directory` (GitHub Actions option) : Only changes the directory where the action runs. All files remain available, only the execution context changes.
-> - `deployPath` (this action's option) : Specifies exactly which files will be sent to Clever Cloud. Allows deploying only a subset of files, like a `dist` or `build` folder.
+> `working-directory` (a GitHub Actions option, not specific to this action)
+> only changes where the action runs — it has the same limitation.
+>
+> `deployPath` is useful when the target directory has its own
+> `.clever.json`, or is itself a separate git repository (e.g. a git
+> submodule).
 
-### Example
+### Deploying a Subfolder of a Monorepo
+
+Neither option subsets the deployed files. To tell Clever Cloud which
+subfolder of the repository to build and run, use the `APP_FOLDER`
+environment variable, set via `setEnv`:
 
 ```yml
-# This will NOT deploy only the build folder:
 - uses: 47ng/actions-clever-cloud@v2.1.1
   with:
-    working-directory: ./build # ❌ Only changes where the action runs
-
-# This will deploy only the build folder:
-- uses: 47ng/actions-clever-cloud@v2.1.1
-  with:
-    deployPath: ./build # ✅ Only sends these files to Clever Cloud
+    setEnv: |
+      APP_FOLDER=packages/backend
 ```
 
-This option is particularly useful for:
-
-- Monorepos where you want to deploy a single package
-- Projects where you only want to deploy built/compiled files
-- Filtering which files are sent to Clever Cloud
-
-Note: The path must be relative to the repository root and must exist.
+Note: `deployPath`, when set, must be relative to the repository root and must exist.

--- a/README.md
+++ b/README.md
@@ -179,6 +179,40 @@ Clever Cloud uses a Git remote to perform deploys. By default, if the commit you
     CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
 ```
 
+## Deploying a Specific Directory
+
+> Support: introduced in v2.1.0
+
+> ⚠️ `deployPath` changes the CLI's working directory only. It does NOT
+> restrict which files get deployed: `clever deploy` always pushes the git
+> HEAD of the repository containing that directory. The Clever CLI locates
+> the repository by walking up from the working directory until it finds a
+> `.git` folder, so a subdirectory of a normal checkout resolves back to the
+> repository root and the entire repository is deployed regardless of this
+> setting.
+>
+> `working-directory` (a GitHub Actions option, not specific to this action)
+> only changes where the action runs — it has the same limitation.
+>
+> `deployPath` is useful when the target directory has its own
+> `.clever.json`, or is itself a separate git repository (e.g. a git
+> submodule).
+
+### Deploying a Subfolder of a Monorepo
+
+Neither option subsets the deployed files. To tell Clever Cloud which
+subfolder of the repository to build and run, use the `APP_FOLDER`
+environment variable, set via `setEnv`:
+
+```yml
+- uses: 47ng/actions-clever-cloud@v2.1.1
+  with:
+    setEnv: |
+      APP_FOLDER=packages/backend
+```
+
+Note: `deployPath`, when set, must be relative to the repository root and must exist.
+
 ## Same Commit Policy
 
 > Support: introduced in v2.1.0
@@ -277,37 +311,3 @@ being published, or after a CI run.
 [MIT](https://github.com/47ng/actions-clever-cloud/blob/master/LICENSE) - Made with ❤️ by [François Best](https://francoisbest.com)
 
 Using this action at work ? [Sponsor me](https://github.com/sponsors/franky47) to help with support and maintenance.
-
-## Running the Clever CLI From a Specific Directory
-
-> Support: introduced in v2.1.0
-
-> ⚠️ `deployPath` changes the CLI's working directory only. It does NOT
-> restrict which files get deployed: `clever deploy` always pushes the git
-> HEAD of the repository containing that directory. The Clever CLI locates
-> the repository by walking up from the working directory until it finds a
-> `.git` folder, so a subdirectory of a normal checkout resolves back to the
-> repository root and the entire repository is deployed regardless of this
-> setting.
->
-> `working-directory` (a GitHub Actions option, not specific to this action)
-> only changes where the action runs — it has the same limitation.
->
-> `deployPath` is useful when the target directory has its own
-> `.clever.json`, or is itself a separate git repository (e.g. a git
-> submodule).
-
-### Deploying a Subfolder of a Monorepo
-
-Neither option subsets the deployed files. To tell Clever Cloud which
-subfolder of the repository to build and run, use the `APP_FOLDER`
-environment variable, set via `setEnv`:
-
-```yml
-- uses: 47ng/actions-clever-cloud@v2.1.1
-  with:
-    setEnv: |
-      APP_FOLDER=packages/backend
-```
-
-Note: `deployPath`, when set, must be relative to the repository root and must exist.

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ $ cat ~/.config/clever-cloud/clever-tools.json
 - `CLEVER_TOKEN`: the `token` value in the credentials
 - `CLEVER_SECRET`: the `secret` value in the credentials
 
-## Extra Environment Variables
+## Extra environment variables
 
 > Support: introduced in v1.2.0
 
@@ -143,7 +143,7 @@ the new instance would use the new variable.
 In the future, we might include a way to rollback environment variables
 set by this action if deployment fails.
 
-## Deployment Timeout
+## Deployment timeout
 
 > Support: introduced in v1.2.0
 
@@ -166,8 +166,8 @@ regardless of the deployment status:
 ## Force deployement
 
 > Support: introduced in v1.2.0
-
-Clever Cloud uses a Git remote to perform deploys. By default, if the commit you want to deploy is not a fast-forward from the commit currently deployed, the deploy will be rejected. You can pass `force: true` to force the deploy anyway:
+> <
+> Clever Cloud uses a Git remote to perform deploys. By default, if the commit you want to deploy is not a fast-forward from the commit currently deployed, the deploy will be rejected. You can pass `force: true` to force the deploy anyway:
 
 ```yml
 - uses: 47ng/actions-clever-cloud@v2.1.1
@@ -179,41 +179,39 @@ Clever Cloud uses a Git remote to perform deploys. By default, if the commit you
     CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
 ```
 
-## Deploying a Specific Directory
+## Deploying a specific app from a monorepo
 
 > Support: introduced in v2.1.0
 
-> ⚠️ `deployPath` changes the CLI's working directory only. It does NOT
-> restrict which files get deployed: `clever deploy` always pushes the git
-> HEAD of the repository containing that directory. The Clever CLI locates
-> the repository by walking up from the working directory until it finds a
-> `.git` folder, so a subdirectory of a normal checkout resolves back to the
-> repository root and the entire repository is deployed regardless of this
-> setting.
->
-> `working-directory` (a GitHub Actions option, not specific to this action)
-> only changes where the action runs — it has the same limitation.
->
-> `deployPath` is useful when the target directory has its own
-> `.clever.json`, or is itself a separate git repository (e.g. a git
-> submodule).
+Clever Cloud receives the whole Git repository. To deploy one app from a monorepo:
 
-### Deploying a Subfolder of a Monorepo
-
-Neither option subsets the deployed files. To tell Clever Cloud which
-subfolder of the repository to build and run, use the `APP_FOLDER`
-environment variable, set via `setEnv`:
+1.  Select the Clever Cloud target app with `alias` or `appID`.
+2.  Set `APP_FOLDER` to the folder that contains the app:
 
 ```yml
 - uses: 47ng/actions-clever-cloud@v2.1.1
   with:
+    alias: backend
     setEnv: |
       APP_FOLDER=packages/backend
+  env:
+    CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
+    CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
 ```
 
-Note: `deployPath`, when set, must be relative to the repository root and must exist.
+`APP_FOLDER` tells Clever Cloud which folder to build and run.
+It does not change which files are sent.
 
-## Same Commit Policy
+### The `deployPath` option
+
+`deployPath` changes the directory where this action runs the Clever CLI. Use
+it when a subfolder has its own `.clever.json`.
+
+It does not limit the files sent to Clever Cloud. The CLI searches parent
+folders for the Git repository, then deploys its current commit. In a normal
+monorepo, the whole repository is still sent.
+
+## Same commit policy
 
 > Support: introduced in v2.1.0
 

--- a/action.yml
+++ b/action.yml
@@ -36,8 +36,9 @@ inputs:
   deployPath:
     required: false
     description: |
-      Specific directory to deploy instead of the entire project.
-      Path must be relative to the repository root.
+      Directory to run the Clever CLI from. This changes which .clever.json
+      is picked up; it does NOT restrict which files are deployed — the CLI
+      always pushes the git repository's HEAD.
   logFile:
     required: false
     description: |

--- a/src/action.test.ts
+++ b/src/action.test.ts
@@ -47,6 +47,7 @@ function makeFakeChild() {
     stdout: PassThrough
     stderr: PassThrough
     kill: ReturnType<typeof vi.fn>
+    unref: ReturnType<typeof vi.fn>
   }
   child.stdout = new PassThrough()
   child.stderr = new PassThrough()
@@ -54,6 +55,7 @@ function makeFakeChild() {
     child.emit('close', null)
     return true
   })
+  child.unref = vi.fn()
   return child
 }
 
@@ -337,6 +339,43 @@ test('timeout escalates to SIGKILL after the termination grace period', async ()
   await finishedRun
   expect(child.kill).toHaveBeenCalledWith('SIGKILL')
   expect(setFailed).not.toHaveBeenCalled()
+})
+
+test('timeout stops waiting when the child stays open after SIGKILL', async () => {
+  vi.useFakeTimers()
+  const child = makeFakeChild()
+  child.kill.mockReturnValue(true)
+  spawnMock.mockReturnValue(child)
+
+  const finishedRun = run({
+    token: 'token',
+    secret: 'secret',
+    cleverCLI: CLEVER_CLI,
+    timeout: 1800
+  })
+  let completed = false
+  void finishedRun.then(() => {
+    completed = true
+  })
+
+  await vi.advanceTimersByTimeAsync(1800 * 1000)
+  await vi.advanceTimersByTimeAsync(5000)
+  expect(child.kill).toHaveBeenCalledWith('SIGKILL')
+  await vi.advanceTimersByTimeAsync(5000)
+
+  try {
+    expect(completed).toBe(true)
+    expect(child.stdout.destroyed).toBe(true)
+    expect(child.stderr.destroyed).toBe(true)
+    expect(child.unref).toHaveBeenCalled()
+  } finally {
+    if (!completed) {
+      child.stdout.end()
+      child.stderr.end()
+      child.emit('close', null)
+      await finishedRun
+    }
+  }
 })
 
 test('deploy completes before timeout: success, no kill', async () => {

--- a/src/action.test.ts
+++ b/src/action.test.ts
@@ -89,9 +89,7 @@ test('deploy default application (no arguments)', async () => {
     secret: 'secret',
     cleverCLI: CLEVER_CLI
   })
-  expect(execMock.mock.calls.some(call => call[1]?.[0] === 'login')).toBe(
-    false
-  )
+  expect(execMock.mock.calls.some(call => call[1]?.[0] === 'login')).toBe(false)
   expectCleverCLICallWithArgs(1, 'deploy')
   expect(setFailed).not.toHaveBeenCalled()
 })
@@ -365,13 +363,22 @@ test('force deploy application', async () => {
   )
 })
 
-test('env-set failure fails the workflow without leaking the value', async () => {
-  execMock.mockImplementation((_cli: string, args: string[]) => {
-    if (args[0] === 'env' && args[1] === 'set') {
-      return Promise.resolve(1)
+test('env-set failure fails the workflow with stderr, without leaking the value, and never deploys', async () => {
+  execMock.mockImplementation(
+    (
+      _cli: string,
+      args: string[],
+      options?: { listeners?: { stderr?: (data: Buffer) => void } }
+    ) => {
+      if (args[0] === 'env' && args[1] === 'set') {
+        options?.listeners?.stderr?.(
+          Buffer.from('Error: environment variable rejected\n')
+        )
+        return Promise.resolve(1)
+      }
+      return Promise.resolve(0)
     }
-    return Promise.resolve(0)
-  })
+  )
   await run({
     token: 'token',
     secret: 'secret',
@@ -381,9 +388,42 @@ test('env-set failure fails the workflow without leaking the value', async () =>
     }
   })
   expect(setFailed).toHaveBeenCalledWith(
-    'Failed to set environment variable foo (exit code 1)'
+    'Failed to set environment variable foo (exit code 1): ' +
+      'Error: environment variable rejected'
   )
   const failureMessage = (setFailed as ReturnType<typeof vi.fn>).mock
     .calls[0]?.[0]
   expect(failureMessage).not.toContain('bar')
+  expect(execMock.mock.calls.some(call => call[1]?.[0] === 'deploy')).toBe(
+    false
+  )
+})
+
+test('spawnDeploy pipes child stderr through the tee (annotations still reach stdout)', async () => {
+  const stdoutSpy = vi
+    .spyOn(process.stdout, 'write')
+    .mockImplementation(() => true)
+  try {
+    vi.useFakeTimers()
+    const child = makeFakeChild()
+    spawnMock.mockReturnValue(child)
+    const finishedRun = run({
+      token: 'token',
+      secret: 'secret',
+      cleverCLI: CLEVER_CLI,
+      timeout: 1800
+    })
+    // Let the pre-deploy steps run and the deploy spawn before touching the
+    // child's streams, same as the other timeout-path tests.
+    await vi.advanceTimersByTimeAsync(1000)
+    child.stderr.write('::error ::deploy failed\n')
+    child.emit('close', 1)
+    await finishedRun
+    const out = stdoutSpy.mock.calls
+      .map((call: unknown[]) => String(call[0]))
+      .join('')
+    expect(out).toContain('::error ::deploy failed')
+  } finally {
+    stdoutSpy.mockRestore()
+  }
 })

--- a/src/action.test.ts
+++ b/src/action.test.ts
@@ -11,6 +11,7 @@ vi.mock('@actions/core', () => ({
   debug: vi.fn(),
   info: vi.fn(),
   warning: vi.fn(),
+  setSecret: vi.fn(),
   setFailed: vi.fn()
 }))
 
@@ -19,7 +20,7 @@ vi.mock('node:child_process', () => ({
   spawn: vi.fn()
 }))
 
-import { setFailed, warning } from '@actions/core'
+import { setFailed, setSecret, warning } from '@actions/core'
 import { exec } from '@actions/exec'
 import { spawn } from 'node:child_process'
 import { run } from './action'
@@ -175,6 +176,10 @@ test('passing extra env variables, using no input args', async () => {
   expectCleverCLICallWithArgs(1, 'env', 'set', 'foo', 'bar')
   expectCleverCLICallWithArgs(2, 'env', 'set', 'egg', 'spam')
   expectCleverCLICallWithArgs(3, 'deploy')
+  expect(setSecret).toHaveBeenCalledWith('bar')
+  expect(setSecret).toHaveBeenCalledWith('spam')
+  expect(execMock.mock.calls[1]?.[2]).toMatchObject({ silent: true })
+  expect(execMock.mock.calls[2]?.[2]).toMatchObject({ silent: true })
 })
 
 test('passing extra env variables, using appID', async () => {
@@ -358,4 +363,27 @@ test('force deploy application', async () => {
     'app_facade42-cafe-babe-cafe-deadf00dbaad',
     '--force'
   )
+})
+
+test('env-set failure fails the workflow without leaking the value', async () => {
+  execMock.mockImplementation((_cli: string, args: string[]) => {
+    if (args[0] === 'env' && args[1] === 'set') {
+      return Promise.resolve(1)
+    }
+    return Promise.resolve(0)
+  })
+  await run({
+    token: 'token',
+    secret: 'secret',
+    cleverCLI: CLEVER_CLI,
+    extraEnv: {
+      foo: 'bar'
+    }
+  })
+  expect(setFailed).toHaveBeenCalledWith(
+    'Failed to set environment variable foo (exit code 1)'
+  )
+  const failureMessage = (setFailed as ReturnType<typeof vi.fn>).mock
+    .calls[0]?.[0]
+  expect(failureMessage).not.toContain('bar')
 })

--- a/src/action.test.ts
+++ b/src/action.test.ts
@@ -20,7 +20,7 @@ vi.mock('node:child_process', () => ({
   spawn: vi.fn()
 }))
 
-import { setFailed, setSecret, warning } from '@actions/core'
+import { setFailed, setSecret } from '@actions/core'
 import { exec } from '@actions/exec'
 import { spawn } from 'node:child_process'
 import { run } from './action'
@@ -102,17 +102,6 @@ test('deploy application with alias', async () => {
     cleverCLI: CLEVER_CLI
   })
   expectCleverCLICallWithArgs(1, 'deploy', '--alias', 'app-alias')
-  expect(setFailed).not.toHaveBeenCalled()
-})
-
-test('deployPath warns that it does not subset deployed files', async () => {
-  await run({
-    token: 'token',
-    secret: 'secret',
-    cleverCLI: CLEVER_CLI,
-    deployPath: '.'
-  })
-  expect(warning).toHaveBeenCalledTimes(1)
   expect(setFailed).not.toHaveBeenCalled()
 })
 

--- a/src/action.test.ts
+++ b/src/action.test.ts
@@ -10,6 +10,7 @@ vi.mock('@actions/exec', () => ({
 vi.mock('@actions/core', () => ({
   debug: vi.fn(),
   info: vi.fn(),
+  warning: vi.fn(),
   setFailed: vi.fn()
 }))
 
@@ -18,7 +19,7 @@ vi.mock('node:child_process', () => ({
   spawn: vi.fn()
 }))
 
-import { setFailed } from '@actions/core'
+import { setFailed, warning } from '@actions/core'
 import { exec } from '@actions/exec'
 import { spawn } from 'node:child_process'
 import { run } from './action'
@@ -102,6 +103,17 @@ test('deploy application with alias', async () => {
     cleverCLI: CLEVER_CLI
   })
   expectCleverCLICallWithArgs(1, 'deploy', '--alias', 'app-alias')
+  expect(setFailed).not.toHaveBeenCalled()
+})
+
+test('deployPath warns that it does not subset deployed files', async () => {
+  await run({
+    token: 'token',
+    secret: 'secret',
+    cleverCLI: CLEVER_CLI,
+    deployPath: '.'
+  })
+  expect(warning).toHaveBeenCalledTimes(1)
   expect(setFailed).not.toHaveBeenCalled()
 })
 

--- a/src/action.test.ts
+++ b/src/action.test.ts
@@ -285,6 +285,71 @@ test('timeout fires: kills the deploy and moves on without failing', async () =>
   expect(setFailed).not.toHaveBeenCalled()
 })
 
+test('timeout waits for asynchronous final output before closing the tee', async () => {
+  const stdoutSpy = vi
+    .spyOn(process.stdout, 'write')
+    .mockImplementation(() => true)
+  try {
+    vi.useFakeTimers()
+    const child = makeFakeChild()
+    child.kill.mockImplementation(() => {
+      setTimeout(() => {
+        child.stdout.end()
+        child.stderr.end('::error ::final timeout detail')
+        child.emit('close', null)
+      }, 50)
+      return true
+    })
+    spawnMock.mockReturnValue(child)
+
+    const finishedRun = run({
+      token: 'token',
+      secret: 'secret',
+      cleverCLI: CLEVER_CLI,
+      timeout: 1800
+    })
+    await vi.advanceTimersByTimeAsync(1800 * 1000)
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM')
+    await vi.advanceTimersByTimeAsync(50)
+    await finishedRun
+
+    const out = stdoutSpy.mock.calls
+      .map((call: unknown[]) => String(call[0]))
+      .join('')
+    expect(out).toContain('::error ::final timeout detail')
+    expect(out).not.toContain('\ufffd')
+  } finally {
+    stdoutSpy.mockRestore()
+  }
+})
+
+test('timeout escalates to SIGKILL after the termination grace period', async () => {
+  vi.useFakeTimers()
+  const child = makeFakeChild()
+  child.kill.mockImplementation((signal: NodeJS.Signals) => {
+    if (signal === 'SIGKILL') {
+      child.stdout.end()
+      child.stderr.end()
+      child.emit('close', null)
+    }
+    return true
+  })
+  spawnMock.mockReturnValue(child)
+
+  const finishedRun = run({
+    token: 'token',
+    secret: 'secret',
+    cleverCLI: CLEVER_CLI,
+    timeout: 1800
+  })
+  await vi.advanceTimersByTimeAsync(1800 * 1000)
+  expect(child.kill).toHaveBeenCalledWith('SIGTERM')
+  await vi.advanceTimersByTimeAsync(5000)
+  await finishedRun
+  expect(child.kill).toHaveBeenCalledWith('SIGKILL')
+  expect(setFailed).not.toHaveBeenCalled()
+})
+
 test('deploy completes before timeout: success, no kill', async () => {
   vi.useFakeTimers()
   const child = makeFakeChild()

--- a/src/action.test.ts
+++ b/src/action.test.ts
@@ -87,15 +87,10 @@ test('deploy default application (no arguments)', async () => {
     secret: 'secret',
     cleverCLI: CLEVER_CLI
   })
-  expectCleverCLICallWithArgs(
-    1,
-    'login',
-    '--token',
-    'token',
-    '--secret',
-    'secret'
+  expect(execMock.mock.calls.some(call => call[1]?.[0] === 'login')).toBe(
+    false
   )
-  expectCleverCLICallWithArgs(2, 'deploy')
+  expectCleverCLICallWithArgs(1, 'deploy')
   expect(setFailed).not.toHaveBeenCalled()
 })
 
@@ -106,7 +101,7 @@ test('deploy application with alias', async () => {
     alias: 'app-alias',
     cleverCLI: CLEVER_CLI
   })
-  expectCleverCLICallWithArgs(2, 'deploy', '--alias', 'app-alias')
+  expectCleverCLICallWithArgs(1, 'deploy', '--alias', 'app-alias')
   expect(setFailed).not.toHaveBeenCalled()
 })
 
@@ -118,14 +113,14 @@ test('deploy application with app ID', async () => {
     cleverCLI: CLEVER_CLI
   })
   expectCleverCLICallWithArgs(
-    2,
+    1,
     'link',
     'app_facade42-cafe-babe-cafe-deadf00dbaad',
     '--alias',
     'app_facade42-cafe-babe-cafe-deadf00dbaad'
   )
   expectCleverCLICallWithArgs(
-    3,
+    2,
     'deploy',
     '--alias',
     'app_facade42-cafe-babe-cafe-deadf00dbaad'
@@ -141,14 +136,14 @@ test('when both app ID and alias are provided, appID takes precedence', async ()
     cleverCLI: CLEVER_CLI
   })
   expectCleverCLICallWithArgs(
-    2,
+    1,
     'link',
     'app_facade42-cafe-babe-cafe-deadf00dbaad',
     '--alias',
     'app_facade42-cafe-babe-cafe-deadf00dbaad'
   )
   expectCleverCLICallWithArgs(
-    3,
+    2,
     'deploy',
     '--alias',
     'app_facade42-cafe-babe-cafe-deadf00dbaad'
@@ -165,9 +160,9 @@ test('passing extra env variables, using no input args', async () => {
       egg: 'spam'
     }
   })
-  expectCleverCLICallWithArgs(2, 'env', 'set', 'foo', 'bar')
-  expectCleverCLICallWithArgs(3, 'env', 'set', 'egg', 'spam')
-  expectCleverCLICallWithArgs(4, 'deploy')
+  expectCleverCLICallWithArgs(1, 'env', 'set', 'foo', 'bar')
+  expectCleverCLICallWithArgs(2, 'env', 'set', 'egg', 'spam')
+  expectCleverCLICallWithArgs(3, 'deploy')
 })
 
 test('passing extra env variables, using appID', async () => {
@@ -182,14 +177,14 @@ test('passing extra env variables, using appID', async () => {
     }
   })
   expectCleverCLICallWithArgs(
-    2,
+    1,
     'link',
     'app_facade42-cafe-babe-cafe-deadf00dbaad',
     '--alias',
     'app_facade42-cafe-babe-cafe-deadf00dbaad'
   )
   expectCleverCLICallWithArgs(
-    3,
+    2,
     'env',
     'set',
     '--alias',
@@ -198,7 +193,7 @@ test('passing extra env variables, using appID', async () => {
     'bar'
   )
   expectCleverCLICallWithArgs(
-    4,
+    3,
     'env',
     'set',
     '--alias',
@@ -207,7 +202,7 @@ test('passing extra env variables, using appID', async () => {
     'spam'
   )
   expectCleverCLICallWithArgs(
-    5,
+    4,
     'deploy',
     '--alias',
     'app_facade42-cafe-babe-cafe-deadf00dbaad'
@@ -225,9 +220,9 @@ test('passing extra env variables, using alias only', async () => {
       egg: 'spam'
     }
   })
-  expectCleverCLICallWithArgs(2, 'env', 'set', '--alias', 'foo', 'foo', 'bar')
-  expectCleverCLICallWithArgs(3, 'env', 'set', '--alias', 'foo', 'egg', 'spam')
-  expectCleverCLICallWithArgs(4, 'deploy', '--alias', 'foo')
+  expectCleverCLICallWithArgs(1, 'env', 'set', '--alias', 'foo', 'foo', 'bar')
+  expectCleverCLICallWithArgs(2, 'env', 'set', '--alias', 'foo', 'egg', 'spam')
+  expectCleverCLICallWithArgs(3, 'deploy', '--alias', 'foo')
 })
 
 test('deployment failure fails the workflow', async () => {
@@ -338,14 +333,14 @@ test('force deploy application', async () => {
     force: true
   })
   expectCleverCLICallWithArgs(
-    2,
+    1,
     'link',
     'app_facade42-cafe-babe-cafe-deadf00dbaad',
     '--alias',
     'app_facade42-cafe-babe-cafe-deadf00dbaad'
   )
   expectCleverCLICallWithArgs(
-    3,
+    2,
     'deploy',
     '--alias',
     'app_facade42-cafe-babe-cafe-deadf00dbaad',

--- a/src/action.ts
+++ b/src/action.ts
@@ -80,8 +80,20 @@ export async function run({
         args.push('--alias', alias)
       }
       args.push(envName, envValue)
+      if (envValue) {
+        core.setSecret(envValue)
+      }
       core.info(`Setting environment variable ${envName}`)
-      await exec(cleverCLI, args, execOptions)
+      const code = await exec(cleverCLI, args, {
+        ...execOptions,
+        silent: true,
+        ignoreReturnCode: true
+      })
+      if (code !== 0) {
+        throw new Error(
+          `Failed to set environment variable ${envName} (exit code ${code})`
+        )
+      }
     }
 
     const args = ['deploy']

--- a/src/action.ts
+++ b/src/action.ts
@@ -52,10 +52,6 @@ export async function run({
         await fs.access(deployPath)
         execOptions.cwd = deployPath
         core.info(`Running Clever CLI from directory: ${deployPath}`)
-        core.warning(
-          'deployPath changes the CLI working directory only. ' +
-            'The deployed payload is the git repository HEAD, not a subset of files.'
-        )
       } catch (error) {
         throw new Error(`Deploy path does not exist: ${deployPath}`)
       }

--- a/src/action.ts
+++ b/src/action.ts
@@ -186,7 +186,7 @@ function spawnDeploy(
   return { child, exited }
 }
 
-async function getOutputStream(
+export async function getOutputStream(
   quiet: boolean,
   logFile?: string
 ): Promise<Writable> {

--- a/src/action.ts
+++ b/src/action.ts
@@ -276,10 +276,16 @@ export async function getOutputStream(
   const tee = new PassThrough()
   const completions: Promise<void>[] = []
   const completionErrors: unknown[] = []
+  let liveSinkCount = 0
   const monitor = (completion: Promise<void>): void => {
+    liveSinkCount += 1
     completions.push(
       completion.catch(error => {
         completionErrors.push(error)
+        liveSinkCount -= 1
+        if (liveSinkCount === 0) {
+          tee.resume()
+        }
       })
     )
   }
@@ -340,6 +346,9 @@ export async function getOutputStream(
     const logFileStream = (await fs.open(logFile, 'w')).createWriteStream()
     tee.pipe(logFileStream)
     monitor(finished(logFileStream))
+  }
+  if (liveSinkCount === 0) {
+    tee.resume()
   }
   const done = async (): Promise<void> => {
     await Promise.all(completions)

--- a/src/action.ts
+++ b/src/action.ts
@@ -8,6 +8,7 @@ import { StringDecoder } from 'node:string_decoder'
 import type { Arguments } from './arguments'
 
 const DEPLOY_TERMINATION_GRACE_PERIOD_MS = 5000
+const DEPLOY_FORCE_KILL_WAIT_MS = 5000
 
 async function checkForShallowCopy(): Promise<void> {
   let output = ''
@@ -167,7 +168,29 @@ export async function run({
           clearTimeout(forceKillTimeoutID)
         }
         if (forced) {
-          await settledExit
+          let forceKillWaitTimeoutID: NodeJS.Timeout | undefined
+          const forceKillWaitPromise = new Promise<boolean>(resolve => {
+            forceKillWaitTimeoutID = setTimeout(
+              () => resolve(false),
+              DEPLOY_FORCE_KILL_WAIT_MS
+            )
+          })
+          const exitedAfterForceKill = await Promise.race([
+            settledExit.then(() => true),
+            forceKillWaitPromise
+          ])
+          if (forceKillWaitTimeoutID) {
+            clearTimeout(forceKillWaitTimeoutID)
+          }
+          if (!exitedAfterForceKill) {
+            if (execOptions.outStream) {
+              child.stdout.unpipe(execOptions.outStream)
+              child.stderr.unpipe(execOptions.outStream)
+            }
+            child.stdout.destroy()
+            child.stderr.destroy()
+            child.unref()
+          }
         }
         core.info('Deployment timed out, moving on with workflow run')
         return
@@ -232,7 +255,7 @@ function spawnDeploy(
 }
 
 const TIMESTAMP_PREFIX_REGEX =
-  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:[+-]\d{2}:\d{2}|Z) /
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:[+-]\d{2}:\d{2}|Z):? /
 
 export type OutputStream = {
   stream: Writable
@@ -252,6 +275,14 @@ export async function getOutputStream(
 ): Promise<OutputStream> {
   const tee = new PassThrough()
   const completions: Promise<void>[] = []
+  const completionErrors: unknown[] = []
+  const monitor = (completion: Promise<void>): void => {
+    completions.push(
+      completion.catch(error => {
+        completionErrors.push(error)
+      })
+    )
+  }
   if (!quiet) {
     let lineSeparator = '\n'
     async function* splitNewlines(
@@ -303,17 +334,17 @@ export async function getOutputStream(
     // `end: false`: process.stdout is shared for the whole action process
     // lifetime — this tee ending must not close it.
     lastTransform.pipe(process.stdout, { end: false })
-    completions.push(finished(lastTransform))
+    monitor(finished(lastTransform))
   }
   if (logFile) {
     const logFileStream = (await fs.open(logFile, 'w')).createWriteStream()
     tee.pipe(logFileStream)
-    completions.push(finished(logFileStream))
+    monitor(finished(logFileStream))
   }
   const done = async (): Promise<void> => {
-    try {
-      await Promise.all(completions)
-    } catch (error) {
+    await Promise.all(completions)
+    if (completionErrors.length > 0) {
+      const error = completionErrors[0]
       core.warning(
         `deploy log output degraded: ${error instanceof Error ? error.message : String(error)}`
       )

--- a/src/action.ts
+++ b/src/action.ts
@@ -282,10 +282,16 @@ export async function getOutputStream(
         yield line + lineSeparator
         // Remove timestamp, if present
         const message = line.replace(TIMESTAMP_PREFIX_REGEX, '')
+        // Only re-emit when a timestamp was actually stripped: a line that
+        // already starts with ::notice/::error/::warning at column 0 (no
+        // timestamp) is echoed above as-is, and the runner parses workflow
+        // commands at line start on its own — re-emitting it here would
+        // duplicate the annotation.
         if (
-          message.startsWith('::notice ') ||
-          message.startsWith('::error ') ||
-          message.startsWith('::warning ')
+          message !== line &&
+          (message.startsWith('::notice ') ||
+            message.startsWith('::error ') ||
+            message.startsWith('::warning '))
         ) {
           yield message + lineSeparator
         }

--- a/src/action.ts
+++ b/src/action.ts
@@ -3,6 +3,7 @@ import { exec, type ExecOptions } from '@actions/exec'
 import { spawn } from 'node:child_process'
 import fs from 'node:fs/promises'
 import { PassThrough, Transform, Writable } from 'node:stream'
+import { finished } from 'node:stream/promises'
 import type { Arguments } from './arguments'
 
 async function checkForShallowCopy(): Promise<void> {
@@ -23,8 +24,6 @@ async function checkForShallowCopy(): Promise<void> {
 }
 
 export async function run({
-  token,
-  secret,
   appID,
   alias,
   force = false,
@@ -36,11 +35,13 @@ export async function run({
   extraEnv = {},
   sameCommitPolicy
 }: Arguments): Promise<void> {
+  let outputStream: OutputStream | undefined
   try {
     await checkForShallowCopy()
 
+    outputStream = await getOutputStream(quiet, logFile)
     const execOptions: ExecOptions = {
-      outStream: await getOutputStream(quiet, logFile)
+      outStream: outputStream.stream
     }
 
     if (deployPath) {
@@ -84,14 +85,21 @@ export async function run({
         core.setSecret(envValue)
       }
       core.info(`Setting environment variable ${envName}`)
+      let stderr = ''
       const code = await exec(cleverCLI, args, {
         ...execOptions,
         silent: true,
-        ignoreReturnCode: true
+        ignoreReturnCode: true,
+        listeners: {
+          stderr: (data: Buffer) => (stderr += data.toString())
+        }
       })
       if (code !== 0) {
+        // stderr may echo the value back (e.g. a rejected value in the CLI's
+        // own error message); safe to surface because setSecret() above
+        // already registered it with the runner's log masking.
         throw new Error(
-          `Failed to set environment variable ${envName} (exit code ${code})`
+          `Failed to set environment variable ${envName} (exit code ${code}): ${stderr.trim()}`
         )
       }
     }
@@ -164,6 +172,14 @@ export async function run({
     } else {
       core.setFailed(String(error))
     }
+  } finally {
+    // Close the tee we opened above so its buffered carry-over line (if any)
+    // and the log file get flushed, even when the timeout path returns early
+    // or the deploy throws.
+    if (outputStream) {
+      outputStream.stream.end()
+      await outputStream.done()
+    }
   }
 }
 
@@ -201,11 +217,24 @@ function spawnDeploy(
 const TIMESTAMP_PREFIX_REGEX =
   /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:[+-]\d{2}:\d{2}|Z) /
 
+export type OutputStream = {
+  stream: Writable
+  /**
+   * Resolves once every sink fed by `stream` (the console pipeline, the log
+   * file) has finished processing whatever was written before `stream.end()`
+   * was called. A sink failing (e.g. ENOSPC, EPIPE) is reported via
+   * `core.warning` rather than rejecting — losing log output must never
+   * override the deploy's real outcome.
+   */
+  done: () => Promise<void>
+}
+
 export async function getOutputStream(
   quiet: boolean,
   logFile?: string
-): Promise<Writable> {
+): Promise<OutputStream> {
   const tee = new PassThrough()
+  const completions: Promise<void>[] = []
   if (!quiet) {
     let lineSeparator = '\n'
     async function* splitNewlines(
@@ -244,14 +273,27 @@ export async function getOutputStream(
         }
       }
     }
-    tee
+    const lastTransform = tee
       .pipe(Transform.from(splitNewlines))
       .pipe(Transform.from(injectAnnotations))
-      .pipe(process.stdout)
+    // `end: false`: process.stdout is shared for the whole action process
+    // lifetime — this tee ending must not close it.
+    lastTransform.pipe(process.stdout, { end: false })
+    completions.push(finished(lastTransform))
   }
   if (logFile) {
     const logFileStream = (await fs.open(logFile, 'w')).createWriteStream()
     tee.pipe(logFileStream)
+    completions.push(finished(logFileStream))
   }
-  return tee
+  const done = async (): Promise<void> => {
+    try {
+      await Promise.all(completions)
+    } catch (error) {
+      core.warning(
+        `deploy log output degraded: ${error instanceof Error ? error.message : String(error)}`
+      )
+    }
+  }
+  return { stream: tee, done }
 }

--- a/src/action.ts
+++ b/src/action.ts
@@ -47,7 +47,11 @@ export async function run({
       try {
         await fs.access(deployPath)
         execOptions.cwd = deployPath
-        core.info(`Deploying from directory: ${deployPath}`)
+        core.info(`Running Clever CLI from directory: ${deployPath}`)
+        core.warning(
+          'deployPath changes the CLI working directory only. ' +
+            'The deployed payload is the git repository HEAD, not a subset of files.'
+        )
       } catch (error) {
         throw new Error(`Deploy path does not exist: ${deployPath}`)
       }

--- a/src/action.ts
+++ b/src/action.ts
@@ -186,6 +186,9 @@ function spawnDeploy(
   return { child, exited }
 }
 
+const TIMESTAMP_PREFIX_REGEX =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:[+-]\d{2}:\d{2}|Z) /
+
 export async function getOutputStream(
   quiet: boolean,
   logFile?: string
@@ -196,15 +199,21 @@ export async function getOutputStream(
     async function* splitNewlines(
       input: AsyncIterable<Buffer>
     ): AsyncGenerator<string> {
+      let carry = ''
       for await (const chunk of input) {
-        const str = Buffer.isBuffer(chunk) ? chunk.toString('utf8') : chunk
+        const str =
+          carry + (Buffer.isBuffer(chunk) ? chunk.toString('utf8') : chunk)
         if (str.includes('\r\n')) {
           lineSeparator = '\r\n'
         }
         const lines = str.split(/\r?\n/)
+        carry = lines.pop() ?? ''
         for (const line of lines) {
           yield line
         }
+      }
+      if (carry.length > 0) {
+        yield carry
       }
     }
     async function* injectAnnotations(
@@ -212,8 +221,8 @@ export async function getOutputStream(
     ): AsyncGenerator<string> {
       for await (const line of lines) {
         yield line + lineSeparator
-        // Remove timestamp
-        const message = line.slice('xxxx-xx-xxTxx:xx:xx+xx:xx '.length)
+        // Remove timestamp, if present
+        const message = line.replace(TIMESTAMP_PREFIX_REGEX, '')
         if (
           message.startsWith('::notice ') ||
           message.startsWith('::error ') ||

--- a/src/action.ts
+++ b/src/action.ts
@@ -55,8 +55,8 @@ export async function run({
 
     core.debug(`Clever CLI path: ${cleverCLI}`)
 
-    // Authenticate (this will only store the credentials at a known location)
-    await exec(cleverCLI, ['login', '--token', token, '--secret', secret])
+    // clever-tools authenticates via the CLEVER_TOKEN / CLEVER_SECRET
+    // environment variables (virtual "$env" profile); no login call needed.
 
     // There is an issue when there is a .clever.json file present
     // and only the appID is passed: link will work, but deploy will need

--- a/src/action.ts
+++ b/src/action.ts
@@ -4,7 +4,10 @@ import { spawn } from 'node:child_process'
 import fs from 'node:fs/promises'
 import { PassThrough, Transform, Writable } from 'node:stream'
 import { finished } from 'node:stream/promises'
+import { StringDecoder } from 'node:string_decoder'
 import type { Arguments } from './arguments'
+
+const DEPLOY_TERMINATION_GRACE_PERIOD_MS = 5000
 
 async function checkForShallowCopy(): Promise<void> {
   let output = ''
@@ -145,13 +148,31 @@ export async function run({
         }
       }
       if (timedOut) {
-        // Stop waiting and let the workflow move on. Killing the child releases
-        // the event loop so the action can exit promptly (the documented
-        // tradeoff: we lose any deployment failure information).
+        // Let the child finish handling SIGTERM and drain its output before the
+        // shared tee is closed in `finally`. Escalate if graceful termination
+        // takes too long.
         child.kill('SIGTERM')
-        // The killed process settles `exited` later; swallow it so it doesn't
-        // surface as an unhandled rejection after we've moved on.
-        exited.catch(() => {})
+        let forceKillTimeoutID: NodeJS.Timeout | undefined
+        const forceKillPromise = new Promise<void>(resolve => {
+          forceKillTimeoutID = setTimeout(() => {
+            child.kill('SIGKILL')
+            resolve()
+          }, DEPLOY_TERMINATION_GRACE_PERIOD_MS)
+        })
+        const settledExit = exited.then(
+          () => undefined,
+          () => undefined
+        )
+        const forced = (await Promise.race([
+          settledExit.then(() => false),
+          forceKillPromise.then(() => true)
+        ])) as boolean
+        if (forceKillTimeoutID) {
+          clearTimeout(forceKillTimeoutID)
+        }
+        if (forced) {
+          await settledExit
+        }
         core.info('Deployment timed out, moving on with workflow run')
         return
       }
@@ -241,9 +262,9 @@ export async function getOutputStream(
       input: AsyncIterable<Buffer>
     ): AsyncGenerator<string> {
       let carry = ''
+      const decoder = new StringDecoder('utf8')
       for await (const chunk of input) {
-        const str =
-          carry + (Buffer.isBuffer(chunk) ? chunk.toString('utf8') : chunk)
+        const str = carry + decoder.write(chunk)
         if (str.includes('\r\n')) {
           lineSeparator = '\r\n'
         }
@@ -253,6 +274,7 @@ export async function getOutputStream(
           yield line
         }
       }
+      carry += decoder.end()
       if (carry.length > 0) {
         yield carry
       }

--- a/src/output-stream.test.ts
+++ b/src/output-stream.test.ts
@@ -1,0 +1,157 @@
+import fs from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, beforeEach, expect, test, vi } from 'vitest'
+import { getOutputStream } from './action'
+
+// getOutputStream tees its non-quiet output into the shared process.stdout.
+// This suite pipes into it repeatedly, which trips Node's 10-listener leak
+// warning without lifting the cap (see the same note in action.test.ts).
+process.stdout.setMaxListeners(0)
+
+// --
+
+// A timestamp prefix matching the shape the current implementation assumes:
+// 'xxxx-xx-xxTxx:xx:xx+xx:xx '.length === 26. Asserted below so this fixture
+// can't silently drift out of sync with the code it's meant to exercise.
+const TS = '2026-07-20T12:00:00+00:00 '
+
+test('fixture sanity: TS is exactly 26 characters (the hardcoded timestamp-prefix length)', () => {
+  expect(TS.length).toBe(26)
+})
+
+let stdoutSpy: ReturnType<typeof vi.spyOn>
+
+beforeEach(() => {
+  stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+})
+
+afterEach(() => {
+  stdoutSpy.mockRestore()
+})
+
+function capturedStdout(): string {
+  return stdoutSpy.mock.calls.map(call => String(call[0])).join('')
+}
+
+// The pipeline is a chain of async generators/streams; give it a couple of
+// ticks to drain after the source ends before asserting on its output.
+async function drain(): Promise<void> {
+  await new Promise(resolve => setImmediate(resolve))
+  await new Promise(resolve => setImmediate(resolve))
+}
+
+async function waitForFileContent(
+  filePath: string,
+  expected: string
+): Promise<void> {
+  await vi.waitFor(
+    async () => {
+      const content = await fs.readFile(filePath, 'utf8').catch(() => '')
+      expect(content).toBe(expected)
+    },
+    { timeout: 2000, interval: 20 }
+  )
+}
+
+function tempLogFilePath(name: string): string {
+  return path.join(
+    tmpdir(),
+    `output-stream-test-${name}-${Date.now()}-${Math.random().toString(36).slice(2)}.log`
+  )
+}
+
+// --
+
+test('non-quiet: a plain line passes through to stdout', async () => {
+  const tee = await getOutputStream(false)
+  tee.write(TS + 'hello\n')
+  tee.end()
+  await drain()
+  expect(capturedStdout()).toContain('hello')
+})
+
+test.each(['notice', 'error', 'warning'])(
+  'non-quiet: ::%s lines are re-emitted without their timestamp',
+  async kind => {
+    const tee = await getOutputStream(false)
+    tee.write(`${TS}::${kind} ::Deployed!\n`)
+    tee.end()
+    await drain()
+    const out = capturedStdout()
+    // Once as the original (timestamped) line, once as the injected
+    // annotation (timestamp stripped).
+    const occurrences = out.split(`::${kind} ::Deployed!`).length - 1
+    expect(occurrences).toBe(2)
+  }
+)
+
+test('non-quiet: non-annotation lines are not re-emitted', async () => {
+  const tee = await getOutputStream(false)
+  tee.write(TS + 'plain\n')
+  tee.end()
+  await drain()
+  const out = capturedStdout()
+  expect(out.split('plain').length - 1).toBe(1)
+})
+
+test('quiet: true suppresses stdout entirely', async () => {
+  const tee = await getOutputStream(true)
+  tee.write(TS + 'hello\n')
+  tee.end()
+  await drain()
+  expect(stdoutSpy).not.toHaveBeenCalled()
+})
+
+test('logFile: receives the raw stream, untouched by annotation injection', async () => {
+  const logFile = tempLogFilePath('raw')
+  const tee = await getOutputStream(false, logFile)
+  tee.write(TS + '::notice ::Deployed!\n')
+  tee.end()
+  await waitForFileContent(logFile, TS + '::notice ::Deployed!\n')
+  await fs.unlink(logFile)
+})
+
+test('quiet + logFile: file gets content, stdout gets nothing', async () => {
+  const logFile = tempLogFilePath('quiet')
+  const tee = await getOutputStream(true, logFile)
+  tee.write(TS + 'hello\n')
+  tee.end()
+  await waitForFileContent(logFile, TS + 'hello\n')
+  expect(stdoutSpy).not.toHaveBeenCalled()
+  await fs.unlink(logFile)
+})
+
+test('non-quiet: adopts \\r\\n as the line separator once seen', async () => {
+  const tee = await getOutputStream(false)
+  tee.write(TS + 'a\r\n')
+  tee.write(TS + '::notice ::x\r\n')
+  tee.end()
+  await drain()
+  const out = capturedStdout()
+  expect(out).toContain('::notice ::x\r\n')
+})
+
+// BUG (pinned): fixed in plan 007 — flip this assertion then.
+test('non-quiet: annotation split across a chunk boundary is NOT detected', async () => {
+  const tee = await getOutputStream(false)
+  tee.write(TS + '::err')
+  tee.write('or ::boom\n')
+  tee.end()
+  await drain()
+  const out = capturedStdout()
+  expect(out).not.toContain('::error ::boom')
+})
+
+// BUG (pinned): fixed in plan 007 — flip this assertion then.
+test('non-quiet: a line without a timestamp prefix loses its annotation', async () => {
+  const tee = await getOutputStream(false)
+  tee.write('::error ::no-timestamp\n')
+  tee.end()
+  await drain()
+  const out = capturedStdout()
+  // The raw line is always echoed once; a properly-detected annotation would
+  // add a second, identical occurrence (no timestamp to strip here). Only one
+  // occurrence means the annotation was NOT injected.
+  expect(out.split('::error ::no-timestamp').length - 1).toBe(1)
+})

--- a/src/output-stream.test.ts
+++ b/src/output-stream.test.ts
@@ -132,26 +132,48 @@ test('non-quiet: adopts \\r\\n as the line separator once seen', async () => {
   expect(out).toContain('::notice ::x\r\n')
 })
 
-// BUG (pinned): fixed in plan 007 — flip this assertion then.
-test('non-quiet: annotation split across a chunk boundary is NOT detected', async () => {
+test('non-quiet: annotation split across a chunk boundary IS detected', async () => {
   const tee = await getOutputStream(false)
   tee.write(TS + '::err')
   tee.write('or ::boom\n')
   tee.end()
   await drain()
   const out = capturedStdout()
-  expect(out).not.toContain('::error ::boom')
+  expect(out).toContain('::error ::boom')
 })
 
-// BUG (pinned): fixed in plan 007 — flip this assertion then.
-test('non-quiet: a line without a timestamp prefix loses its annotation', async () => {
+test('non-quiet: a line without a timestamp prefix keeps its annotation', async () => {
   const tee = await getOutputStream(false)
   tee.write('::error ::no-timestamp\n')
   tee.end()
   await drain()
   const out = capturedStdout()
-  // The raw line is always echoed once; a properly-detected annotation would
-  // add a second, identical occurrence (no timestamp to strip here). Only one
-  // occurrence means the annotation was NOT injected.
-  expect(out.split('::error ::no-timestamp').length - 1).toBe(1)
+  // The raw line is echoed once, and the detected annotation adds a second,
+  // identical occurrence (no timestamp to strip here).
+  expect(out.split('::error ::no-timestamp').length - 1).toBe(2)
+})
+
+test('non-quiet: a Z-suffixed timestamp is stripped before annotation detection', async () => {
+  const tee = await getOutputStream(false)
+  tee.write('2026-07-20T12:00:00Z ::error ::zulu\n')
+  tee.end()
+  await drain()
+  const out = capturedStdout()
+  expect(out.split('::error ::zulu').length - 1).toBe(2)
+})
+
+test('non-quiet: a chunk ending exactly on \\n produces no phantom empty line', async () => {
+  const tee = await getOutputStream(false)
+  tee.write(TS + 'a\n')
+  tee.end()
+  await drain()
+  expect(capturedStdout()).toBe(TS + 'a\n')
+})
+
+test('non-quiet: an unterminated final line is still emitted after end()', async () => {
+  const tee = await getOutputStream(false)
+  tee.write(TS + 'no-trailing-newline')
+  tee.end()
+  await drain()
+  expect(capturedStdout()).toContain('no-trailing-newline')
 })

--- a/src/output-stream.test.ts
+++ b/src/output-stream.test.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
+import { Writable } from 'node:stream'
 import { afterEach, beforeEach, expect, test, vi } from 'vitest'
 import { getOutputStream } from './action'
 
@@ -112,6 +113,25 @@ test('quiet + logFile: file gets content, stdout gets nothing', async () => {
   await fs.unlink(logFile)
 })
 
+test('log sink failure is handled before done is called', async () => {
+  const sink = new Writable({
+    write(_chunk, _encoding, callback) {
+      callback(new Error('disk full'))
+    }
+  })
+  const openSpy = vi.spyOn(fs, 'open').mockResolvedValue({
+    createWriteStream: () => sink
+  } as never)
+  try {
+    const { stream, done } = await getOutputStream(true, 'deploy.log')
+    stream.end('deploy output')
+    await new Promise(resolve => setImmediate(resolve))
+    await expect(done()).resolves.toBeUndefined()
+  } finally {
+    openSpy.mockRestore()
+  }
+})
+
 test('non-quiet: adopts \\r\\n as the line separator once seen', async () => {
   const { stream, done } = await getOutputStream(false)
   stream.write(TS + 'a\r\n')
@@ -157,9 +177,9 @@ test('non-quiet: a line without a timestamp prefix is not duplicated', async () 
   expect(out.split('::error ::no-timestamp').length - 1).toBe(1)
 })
 
-test('non-quiet: a Z-suffixed timestamp is stripped before annotation detection', async () => {
+test('non-quiet: a Clever CLI timestamp is stripped before annotation detection', async () => {
   const { stream, done } = await getOutputStream(false)
-  stream.write('2026-07-20T12:00:00Z ::error ::zulu\n')
+  stream.write('2026-07-20T12:00:00.000Z: ::error ::zulu\n')
   stream.end()
   await done()
   const out = capturedStdout()

--- a/src/output-stream.test.ts
+++ b/src/output-stream.test.ts
@@ -132,6 +132,19 @@ test('non-quiet: annotation split across a chunk boundary IS detected', async ()
   expect(out).toContain('::error ::boom')
 })
 
+test('non-quiet: a multi-byte character split across chunks is decoded intact', async () => {
+  const { stream, done } = await getOutputStream(false)
+  const line = Buffer.from(TS + '::error ::d\u00e9ploy\n')
+  const splitAt = line.indexOf(Buffer.from('\u00e9')) + 1
+  stream.write(line.subarray(0, splitAt))
+  stream.write(line.subarray(splitAt))
+  stream.end()
+  await done()
+  const out = capturedStdout()
+  expect(out.split('::error ::d\u00e9ploy').length - 1).toBe(2)
+  expect(out).not.toContain('\ufffd')
+})
+
 test('non-quiet: a line without a timestamp prefix keeps its annotation', async () => {
   const { stream, done } = await getOutputStream(false)
   stream.write('::error ::no-timestamp\n')

--- a/src/output-stream.test.ts
+++ b/src/output-stream.test.ts
@@ -31,27 +31,7 @@ afterEach(() => {
 })
 
 function capturedStdout(): string {
-  return stdoutSpy.mock.calls.map(call => String(call[0])).join('')
-}
-
-// The pipeline is a chain of async generators/streams; give it a couple of
-// ticks to drain after the source ends before asserting on its output.
-async function drain(): Promise<void> {
-  await new Promise(resolve => setImmediate(resolve))
-  await new Promise(resolve => setImmediate(resolve))
-}
-
-async function waitForFileContent(
-  filePath: string,
-  expected: string
-): Promise<void> {
-  await vi.waitFor(
-    async () => {
-      const content = await fs.readFile(filePath, 'utf8').catch(() => '')
-      expect(content).toBe(expected)
-    },
-    { timeout: 2000, interval: 20 }
-  )
+  return stdoutSpy.mock.calls.map((call: unknown[]) => String(call[0])).join('')
 }
 
 function tempLogFilePath(name: string): string {
@@ -64,20 +44,20 @@ function tempLogFilePath(name: string): string {
 // --
 
 test('non-quiet: a plain line passes through to stdout', async () => {
-  const tee = await getOutputStream(false)
-  tee.write(TS + 'hello\n')
-  tee.end()
-  await drain()
+  const { stream, done } = await getOutputStream(false)
+  stream.write(TS + 'hello\n')
+  stream.end()
+  await done()
   expect(capturedStdout()).toContain('hello')
 })
 
 test.each(['notice', 'error', 'warning'])(
   'non-quiet: ::%s lines are re-emitted without their timestamp',
   async kind => {
-    const tee = await getOutputStream(false)
-    tee.write(`${TS}::${kind} ::Deployed!\n`)
-    tee.end()
-    await drain()
+    const { stream, done } = await getOutputStream(false)
+    stream.write(`${TS}::${kind} ::Deployed!\n`)
+    stream.end()
+    await done()
     const out = capturedStdout()
     // Once as the original (timestamped) line, once as the injected
     // annotation (timestamp stripped).
@@ -87,66 +67,76 @@ test.each(['notice', 'error', 'warning'])(
 )
 
 test('non-quiet: non-annotation lines are not re-emitted', async () => {
-  const tee = await getOutputStream(false)
-  tee.write(TS + 'plain\n')
-  tee.end()
-  await drain()
+  const { stream, done } = await getOutputStream(false)
+  stream.write(TS + 'plain\n')
+  stream.end()
+  await done()
   const out = capturedStdout()
   expect(out.split('plain').length - 1).toBe(1)
 })
 
 test('quiet: true suppresses stdout entirely', async () => {
-  const tee = await getOutputStream(true)
-  tee.write(TS + 'hello\n')
-  tee.end()
-  await drain()
+  const { stream, done } = await getOutputStream(true)
+  stream.write(TS + 'hello\n')
+  stream.end()
+  await done()
   expect(stdoutSpy).not.toHaveBeenCalled()
 })
 
-test('logFile: receives the raw stream, untouched by annotation injection', async () => {
+test('logFile + non-quiet: the file gets the raw stream AND stdout gets the processed stream', async () => {
   const logFile = tempLogFilePath('raw')
-  const tee = await getOutputStream(false, logFile)
-  tee.write(TS + '::notice ::Deployed!\n')
-  tee.end()
-  await waitForFileContent(logFile, TS + '::notice ::Deployed!\n')
+  const { stream, done } = await getOutputStream(false, logFile)
+  stream.write(TS + '::notice ::Deployed!\n')
+  stream.end()
+  await done()
+  const content = await fs.readFile(logFile, 'utf8')
+  // The log file receives the tee's raw input, untouched by annotation
+  // injection: exactly the one line that was written, timestamp intact.
+  expect(content).toBe(TS + '::notice ::Deployed!\n')
+  // stdout receives the processed stream: the original line plus the
+  // injected (timestamp-stripped) annotation — two occurrences pin that
+  // both sinks actually fed off the same tee, not just one or the other.
+  expect(capturedStdout().split('::notice ::Deployed!').length - 1).toBe(2)
   await fs.unlink(logFile)
 })
 
 test('quiet + logFile: file gets content, stdout gets nothing', async () => {
   const logFile = tempLogFilePath('quiet')
-  const tee = await getOutputStream(true, logFile)
-  tee.write(TS + 'hello\n')
-  tee.end()
-  await waitForFileContent(logFile, TS + 'hello\n')
+  const { stream, done } = await getOutputStream(true, logFile)
+  stream.write(TS + 'hello\n')
+  stream.end()
+  await done()
+  const content = await fs.readFile(logFile, 'utf8')
+  expect(content).toBe(TS + 'hello\n')
   expect(stdoutSpy).not.toHaveBeenCalled()
   await fs.unlink(logFile)
 })
 
 test('non-quiet: adopts \\r\\n as the line separator once seen', async () => {
-  const tee = await getOutputStream(false)
-  tee.write(TS + 'a\r\n')
-  tee.write(TS + '::notice ::x\r\n')
-  tee.end()
-  await drain()
+  const { stream, done } = await getOutputStream(false)
+  stream.write(TS + 'a\r\n')
+  stream.write(TS + '::notice ::x\r\n')
+  stream.end()
+  await done()
   const out = capturedStdout()
   expect(out).toContain('::notice ::x\r\n')
 })
 
 test('non-quiet: annotation split across a chunk boundary IS detected', async () => {
-  const tee = await getOutputStream(false)
-  tee.write(TS + '::err')
-  tee.write('or ::boom\n')
-  tee.end()
-  await drain()
+  const { stream, done } = await getOutputStream(false)
+  stream.write(TS + '::err')
+  stream.write('or ::boom\n')
+  stream.end()
+  await done()
   const out = capturedStdout()
   expect(out).toContain('::error ::boom')
 })
 
 test('non-quiet: a line without a timestamp prefix keeps its annotation', async () => {
-  const tee = await getOutputStream(false)
-  tee.write('::error ::no-timestamp\n')
-  tee.end()
-  await drain()
+  const { stream, done } = await getOutputStream(false)
+  stream.write('::error ::no-timestamp\n')
+  stream.end()
+  await done()
   const out = capturedStdout()
   // The raw line is echoed once, and the detected annotation adds a second,
   // identical occurrence (no timestamp to strip here).
@@ -154,26 +144,26 @@ test('non-quiet: a line without a timestamp prefix keeps its annotation', async 
 })
 
 test('non-quiet: a Z-suffixed timestamp is stripped before annotation detection', async () => {
-  const tee = await getOutputStream(false)
-  tee.write('2026-07-20T12:00:00Z ::error ::zulu\n')
-  tee.end()
-  await drain()
+  const { stream, done } = await getOutputStream(false)
+  stream.write('2026-07-20T12:00:00Z ::error ::zulu\n')
+  stream.end()
+  await done()
   const out = capturedStdout()
   expect(out.split('::error ::zulu').length - 1).toBe(2)
 })
 
 test('non-quiet: a chunk ending exactly on \\n produces no phantom empty line', async () => {
-  const tee = await getOutputStream(false)
-  tee.write(TS + 'a\n')
-  tee.end()
-  await drain()
+  const { stream, done } = await getOutputStream(false)
+  stream.write(TS + 'a\n')
+  stream.end()
+  await done()
   expect(capturedStdout()).toBe(TS + 'a\n')
 })
 
-test('non-quiet: an unterminated final line is still emitted after end()', async () => {
-  const tee = await getOutputStream(false)
-  tee.write(TS + 'no-trailing-newline')
-  tee.end()
-  await drain()
+test('non-quiet: an unterminated final line is still emitted after end() — reflects production, where run() always ends the stream', async () => {
+  const { stream, done } = await getOutputStream(false)
+  stream.write(TS + 'no-trailing-newline')
+  stream.end()
+  await done()
   expect(capturedStdout()).toContain('no-trailing-newline')
 })

--- a/src/output-stream.test.ts
+++ b/src/output-stream.test.ts
@@ -145,15 +145,16 @@ test('non-quiet: a multi-byte character split across chunks is decoded intact', 
   expect(out).not.toContain('\ufffd')
 })
 
-test('non-quiet: a line without a timestamp prefix keeps its annotation', async () => {
+test('non-quiet: a line without a timestamp prefix is not duplicated', async () => {
   const { stream, done } = await getOutputStream(false)
   stream.write('::error ::no-timestamp\n')
   stream.end()
   await done()
   const out = capturedStdout()
-  // The raw line is echoed once, and the detected annotation adds a second,
-  // identical occurrence (no timestamp to strip here).
-  expect(out.split('::error ::no-timestamp').length - 1).toBe(2)
+  // No timestamp was stripped, so no annotation is injected: the runner
+  // already parses this workflow command from the raw, column-0 line.
+  // Re-emitting it here would duplicate the annotation.
+  expect(out.split('::error ::no-timestamp').length - 1).toBe(1)
 })
 
 test('non-quiet: a Z-suffixed timestamp is stripped before annotation detection', async () => {

--- a/src/output-stream.test.ts
+++ b/src/output-stream.test.ts
@@ -113,7 +113,7 @@ test('quiet + logFile: file gets content, stdout gets nothing', async () => {
   await fs.unlink(logFile)
 })
 
-test('log sink failure is handled before done is called', async () => {
+test('log sink failure is handled early and later output keeps draining', async () => {
   const sink = new Writable({
     write(_chunk, _encoding, callback) {
       callback(new Error('disk full'))
@@ -124,8 +124,16 @@ test('log sink failure is handled before done is called', async () => {
   } as never)
   try {
     const { stream, done } = await getOutputStream(true, 'deploy.log')
-    stream.end('deploy output')
+    stream.write('first output')
     await new Promise(resolve => setImmediate(resolve))
+
+    for (let index = 0; index < 256; index += 1) {
+      stream.write(Buffer.alloc(1024))
+    }
+    await new Promise(resolve => setImmediate(resolve))
+    expect(stream.writableLength).toBe(0)
+
+    stream.end()
     await expect(done()).resolves.toBeUndefined()
   } finally {
     openSpy.mockRestore()


### PR DESCRIPTION
Stacked changes to the action core, ordered so each builds on the previous.

Credentials: the action ran `clever login --token ... --secret ...`, putting both secrets on argv and into the echoed command line. clever-tools v4 reads `CLEVER_TOKEN` and `CLEVER_SECRET` from the environment on its own (virtual `$env` profile), so the login call is gone entirely.

deployPath: the README claimed it deploys only a subset of files. It never did. clever-tools walks up from the working directory to the nearest `.git` and pushes HEAD, so the whole repo was always deployed. Docs now say what actually happens and point monorepo users at `APP_FOLDER` instead.

Log pipeline: the output stream splitter had no cross-chunk buffer, so a log line spanning two stream chunks was split in half and annotations (`::error` etc.) crossing a boundary were lost. It also assumed every line starts with a fixed 26-char timestamp and ate 26 chars of content when one did not. Both fixed, pinned first by characterization tests. Annotations already parsed by the runner (column-0 workflow commands) are not re-emitted, so no duplicates. Multi-byte UTF-8 sequences split across chunks decode correctly.

setEnv values: the env-set subprocess echoed `env set KEY VALUE` into the tee that feeds the console and the logFile artifact. Runner masking does not reach uploaded artifacts, so secrets could land there in plaintext. Values are now registered with `core.setSecret`, the call runs silent, and failures surface the CLI's stderr with the variable name, never the value.

Lifecycle: the output tee is now ended and drained before the action returns, so the log file is complete and a process dying mid-line keeps its final line. On timeout the child gets SIGTERM, a 5 second grace period to flush its output, then SIGKILL.

Plans 002, 004, 006, 007, 008 from the advisor audit, plus fixes from three review agents and a breaking-change round. Suite grows from 32 to 52 tests.
