### PR TITLE
fix: patch vulnerable transitive deps (simple-git, lodash)

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -9,6 +9,7 @@ on:
       - "Dockerfile"
       - "package.json"
       - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
       - "tsconfig.json"
 
 permissions: {}

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM node:24.9.0-slim AS builder
 
 WORKDIR /action
 
-COPY package.json pnpm-lock.yaml  ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 
 RUN corepack enable
 RUN pnpm install --frozen-lockfile --ignore-scripts

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  simple-git: '>=3.36.0'
+  lodash: '>=4.17.24'
+
 importers:
 
   .:
@@ -918,6 +922,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@simple-git/args-pathspec@1.0.3':
+    resolution: {integrity: sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA==}
+
+  '@simple-git/argv-parser@1.1.1':
+    resolution: {integrity: sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -1435,8 +1445,8 @@ packages:
   lodash.isarguments@3.1.0:
     resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
 
-  lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -1640,8 +1650,8 @@ packages:
   simple-get@4.0.1:
     resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
 
-  simple-git@3.30.0:
-    resolution: {integrity: sha512-q6lxyDsCmEal/MEGhP1aVyQ3oxnagGlBDOVSIB4XUVLl1iZh0Pah6ebC9V4xBap/RfgP2WlI8EKs0WS0rMEJHg==}
+  simple-git@3.36.0:
+    resolution: {integrity: sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q==}
 
   slugify@1.6.6:
     resolution: {integrity: sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==}
@@ -2561,6 +2571,12 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.52.3':
     optional: true
 
+  '@simple-git/args-pathspec@1.0.3': {}
+
+  '@simple-git/argv-parser@1.1.1':
+    dependencies:
+      '@simple-git/args-pathspec': 1.0.3
+
   '@standard-schema/spec@1.1.0': {}
 
   '@tybys/wasm-util@0.10.3':
@@ -2728,10 +2744,10 @@ snapshots:
       iso8601-duration: 2.1.3
       isomorphic-git: 1.35.1
       linux-release-info: 3.0.0
-      lodash: 4.17.21
+      lodash: 4.18.1
       open: 10.2.0
       semver: 7.7.3
-      simple-git: 3.30.0
+      simple-git: 3.36.0
       slugify: 1.6.6
       tldts: 7.0.19
       update-notifier: 7.3.1
@@ -2748,7 +2764,7 @@ snapshots:
 
   cliparse@0.5.0:
     dependencies:
-      lodash: 4.17.21
+      lodash: 4.18.1
       minimist: 1.2.8
 
   cluster-key-slot@1.1.2: {}
@@ -3079,7 +3095,7 @@ snapshots:
 
   lodash.isarguments@3.1.0: {}
 
-  lodash@4.17.21: {}
+  lodash@4.18.1: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -3335,10 +3351,12 @@ snapshots:
       once: 1.4.0
       simple-concat: 1.0.1
 
-  simple-git@3.30.0:
+  simple-git@3.36.0:
     dependencies:
       '@kwsites/file-exists': 1.1.1
       '@kwsites/promise-deferred': 1.1.1
+      '@simple-git/args-pathspec': 1.0.3
+      '@simple-git/argv-parser': 1.1.1
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,6 @@
 allowBuilds:
   esbuild: true
+
+overrides:
+  simple-git: '>=3.36.0'
+  lodash: '>=4.17.24'


### PR DESCRIPTION
`pnpm audit --prod` reports 6 advisories through clever-tools: a critical and two high in simple-git, plus a high and two moderate in lodash. No clever-tools release ships patched versions yet (4.11.0 pins simple-git 3.30.0 and lodash 4.17.21), so this adds overrides in `pnpm-workspace.yaml` (where pnpm 11 reads them; the `pnpm` field in package.json is ignored since v10).

None of the six look reachable in this action's deploy path, so this is about keeping the audit clean rather than patching a live hole. simple-git only runs behind clever-tools' opt-in `system-git` beta; the default backend is isomorphic-git and the action never enables the flag, so that code stays dormant. The lodash advisories need `_.template` or attacker-controlled `_.unset`/`_.omit` paths, none of which clever-tools reaches. Keeping the tree audit-clean still has value: it removes noise for anyone scanning this action, and it costs nothing at runtime.

Audit is clean after the change, tests pass, and `clever deploy` completes a real deployment in the Docker CI job. The 3.30.0 to 3.36.0 range is security hardening of argument and config validation, with no changes to the API surface clever-tools uses.

Drop these overrides once clever-tools bumps its own deps past the patched ranges.

Plan 003 from the advisor audit.
