### PR TITLE
fix: warn on ignored setEnv lines, reject invalid timeout values

### DIFF
--- a/src/arguments.test.ts
+++ b/src/arguments.test.ts
@@ -1,5 +1,21 @@
+import * as core from '@actions/core'
 import { afterEach, beforeEach, expect, test, vitest } from 'vitest'
 import { processArguments } from './arguments'
+
+// `@actions/core` is real ESM, whose named exports are not configurable,
+// so `vi.spyOn(core, 'warning')` cannot redefine it in place. Mock only
+// `warning`, passing every other export through untouched, so input
+// parsing still reads real `INPUT_*` / `process.env` values as everywhere
+// else in this file.
+vitest.mock('@actions/core', async importOriginal => {
+  const actual = await importOriginal<typeof import('@actions/core')>()
+  return {
+    ...actual,
+    warning: vitest.fn()
+  }
+})
+
+const warn = vitest.mocked(core.warning)
 
 // --
 
@@ -12,6 +28,7 @@ beforeEach(() => {
   process.env.INPUT_FORCE = 'false'
   process.env.INPUT_QUIET = 'false'
   delete process.env.NODE_ENV
+  warn.mockClear()
 })
 
 afterEach(() => {
@@ -51,6 +68,19 @@ test('extra env', () => {
   expect(args.extraEnv!['123']).toEqual('456')
   expect(args.extraEnv!.many_equals).toEqual('dod==d=doodod=d')
   expect(args.extraEnv!.EVIL).toBeUndefined()
+  expect(warn).not.toHaveBeenCalled()
+})
+
+test('extra env, dash key is dropped with a warning that redacts the value', () => {
+  process.env.INPUT_SETENV = 'MY-VAR=super-secret'
+  process.env.CLEVER_TOKEN = 'token'
+  process.env.CLEVER_SECRET = 'secret'
+  const args = processArguments()
+  expect(args.extraEnv).toBeDefined()
+  expect(args.extraEnv!['MY-VAR']).toBeUndefined()
+  expect(warn).toHaveBeenCalledTimes(1)
+  const message = warn.mock.calls[0]![0] as string
+  expect(message).not.toContain('super-secret')
 })
 
 test('timeout, default value is undefined', () => {
@@ -73,8 +103,24 @@ test('timeout, default value is not a number', () => {
   process.env.CLEVER_TOKEN = 'token'
   process.env.CLEVER_SECRET = 'secret'
   process.env.INPUT_TIMEOUT = 'nope'
-  const args = processArguments()
-  expect(args.timeout).toBeUndefined()
+  const run = () => processArguments()
+  expect(run).toThrow()
+})
+
+test('timeout, negative value throws', () => {
+  process.env.CLEVER_TOKEN = 'token'
+  process.env.CLEVER_SECRET = 'secret'
+  process.env.INPUT_TIMEOUT = '-5'
+  const run = () => processArguments()
+  expect(run).toThrow()
+})
+
+test('timeout, garbage value throws', () => {
+  process.env.CLEVER_TOKEN = 'token'
+  process.env.CLEVER_SECRET = 'secret'
+  process.env.INPUT_TIMEOUT = '12abc'
+  const run = () => processArguments()
+  expect(run).toThrow()
 })
 
 test('force, default value is false', () => {

--- a/src/arguments.test.ts
+++ b/src/arguments.test.ts
@@ -152,6 +152,22 @@ test('timeout, garbage value throws', () => {
   expect(run).toThrow()
 })
 
+test('timeout, 24 hours is accepted', () => {
+  process.env.CLEVER_TOKEN = 'token'
+  process.env.CLEVER_SECRET = 'secret'
+  process.env.INPUT_TIMEOUT = '86400'
+  const args = processArguments()
+  expect(args.timeout).toEqual(86400)
+})
+
+test('timeout, first value above 24 hours throws', () => {
+  process.env.CLEVER_TOKEN = 'token'
+  process.env.CLEVER_SECRET = 'secret'
+  process.env.INPUT_TIMEOUT = '86401'
+  const run = () => processArguments()
+  expect(run).toThrow()
+})
+
 test('force, default value is false', () => {
   process.env.CLEVER_TOKEN = 'token'
   process.env.CLEVER_SECRET = 'secret'

--- a/src/arguments.test.ts
+++ b/src/arguments.test.ts
@@ -136,18 +136,42 @@ test('timeout, negative value throws', () => {
   expect(run).toThrow()
 })
 
-test('timeout, zero throws', () => {
+test('timeout, zero means no timeout', () => {
   process.env.CLEVER_TOKEN = 'token'
   process.env.CLEVER_SECRET = 'secret'
   process.env.INPUT_TIMEOUT = '0'
-  const run = () => processArguments()
-  expect(run).toThrow()
+  const args = processArguments()
+  expect(args.timeout).toBeUndefined()
 })
 
 test('timeout, garbage value throws', () => {
   process.env.CLEVER_TOKEN = 'token'
   process.env.CLEVER_SECRET = 'secret'
   process.env.INPUT_TIMEOUT = '12abc'
+  const run = () => processArguments()
+  expect(run).toThrow()
+})
+
+test('timeout, scientific notation throws', () => {
+  process.env.CLEVER_TOKEN = 'token'
+  process.env.CLEVER_SECRET = 'secret'
+  process.env.INPUT_TIMEOUT = '1e3'
+  const run = () => processArguments()
+  expect(run).toThrow()
+})
+
+test('timeout, hexadecimal notation throws', () => {
+  process.env.CLEVER_TOKEN = 'token'
+  process.env.CLEVER_SECRET = 'secret'
+  process.env.INPUT_TIMEOUT = '0x10'
+  const run = () => processArguments()
+  expect(run).toThrow()
+})
+
+test('timeout, leading plus sign throws', () => {
+  process.env.CLEVER_TOKEN = 'token'
+  process.env.CLEVER_SECRET = 'secret'
+  process.env.INPUT_TIMEOUT = '+5'
   const run = () => processArguments()
   expect(run).toThrow()
 })

--- a/src/arguments.test.ts
+++ b/src/arguments.test.ts
@@ -81,6 +81,27 @@ test('extra env, dash key is dropped with a warning that redacts the value', () 
   expect(warn).toHaveBeenCalledTimes(1)
   const message = warn.mock.calls[0]![0] as string
   expect(message).not.toContain('super-secret')
+  expect(message).toContain('MY-VAR=***')
+})
+
+test('extra env, line without = never echoes its content', () => {
+  process.env.INPUT_SETENV = 'sk_live_totallyASecretToken'
+  process.env.CLEVER_TOKEN = 'token'
+  process.env.CLEVER_SECRET = 'secret'
+  processArguments()
+  expect(warn).toHaveBeenCalledTimes(1)
+  const message = warn.mock.calls[0]![0] as string
+  expect(message).not.toContain('sk_live_totallyASecretToken')
+})
+
+test('extra env, whitespace-only line between valid vars is skipped without a warning', () => {
+  process.env.INPUT_SETENV = 'FOO=foo\n   \nBAR=bar'
+  process.env.CLEVER_TOKEN = 'token'
+  process.env.CLEVER_SECRET = 'secret'
+  const args = processArguments()
+  expect(args.extraEnv!.FOO).toEqual('foo')
+  expect(args.extraEnv!.BAR).toEqual('bar')
+  expect(warn).not.toHaveBeenCalled()
 })
 
 test('timeout, default value is undefined', () => {
@@ -111,6 +132,14 @@ test('timeout, negative value throws', () => {
   process.env.CLEVER_TOKEN = 'token'
   process.env.CLEVER_SECRET = 'secret'
   process.env.INPUT_TIMEOUT = '-5'
+  const run = () => processArguments()
+  expect(run).toThrow()
+})
+
+test('timeout, zero throws', () => {
+  process.env.CLEVER_TOKEN = 'token'
+  process.env.CLEVER_SECRET = 'secret'
+  process.env.INPUT_TIMEOUT = '0'
   const run = () => processArguments()
   expect(run).toThrow()
 })

--- a/src/arguments.ts
+++ b/src/arguments.ts
@@ -30,6 +30,7 @@ function throwMissingEnvVar(name: string): never {
 }
 
 const ENV_LINE_REGEX = /^(\w+)=(.*)$/
+const MAX_TIMEOUT_SECONDS = 24 * 60 * 60
 
 function redactValue(line: string): string {
   const equalsIndex = line.indexOf('=')
@@ -91,9 +92,13 @@ export function processArguments(): Arguments {
   let timeout: number | undefined = undefined
   if (timeoutInput) {
     const parsed = Number(timeoutInput)
-    if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    if (
+      !Number.isSafeInteger(parsed) ||
+      parsed <= 0 ||
+      parsed > MAX_TIMEOUT_SECONDS
+    ) {
       throw new Error(
-        `Invalid timeout value: ${timeoutInput} (expected a positive integer number of seconds)`
+        `Invalid timeout value: ${timeoutInput} (expected an integer number of seconds between 1 and ${MAX_TIMEOUT_SECONDS})`
       )
     }
     timeout = parsed

--- a/src/arguments.ts
+++ b/src/arguments.ts
@@ -31,6 +31,14 @@ function throwMissingEnvVar(name: string): never {
 
 const ENV_LINE_REGEX = /^(\w+)=(.*)$/
 
+function redactValue(line: string): string {
+  const equalsIndex = line.indexOf('=')
+  if (equalsIndex === -1) {
+    return line
+  }
+  return `${line.slice(0, equalsIndex)}=***`
+}
+
 function listExtraEnv(): ExtraEnv {
   const extraEnv = core
     .getMultilineInput('setEnv')
@@ -39,6 +47,11 @@ function listExtraEnv(): ExtraEnv {
       (env, line) => {
         const match = line.match(ENV_LINE_REGEX)
         if (!match) {
+          if (!line.startsWith('#')) {
+            core.warning(
+              `Ignoring setEnv line that is not KEY=value (keys are [A-Za-z0-9_]): ${redactValue(line)}`
+            )
+          }
           return env
         }
         const key = match[1]!
@@ -71,7 +84,17 @@ export function processArguments(): Arguments {
   const appID = core.getInput('appID')
   const alias = core.getInput('alias')
   const force = core.getBooleanInput('force', { required: false })
-  const timeout = parseInt(core.getInput('timeout')) || undefined
+  const timeoutInput = core.getInput('timeout')
+  let timeout: number | undefined = undefined
+  if (timeoutInput) {
+    const parsed = Number(timeoutInput)
+    if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+      throw new Error(
+        `Invalid timeout value: ${timeoutInput} (expected a positive integer number of seconds)`
+      )
+    }
+    timeout = parsed
+  }
   const logFile = core.getInput('logFile') || undefined
   const quiet = core.getBooleanInput('quiet', { required: false })
   const deployPath = core.getInput('deployPath') || undefined

--- a/src/arguments.ts
+++ b/src/arguments.ts
@@ -34,7 +34,7 @@ const ENV_LINE_REGEX = /^(\w+)=(.*)$/
 function redactValue(line: string): string {
   const equalsIndex = line.indexOf('=')
   if (equalsIndex === -1) {
-    return line
+    return `(content hidden, no '=' found)`
   }
   return `${line.slice(0, equalsIndex)}=***`
 }
@@ -45,6 +45,9 @@ function listExtraEnv(): ExtraEnv {
     .map(line => line.trim())
     .reduce(
       (env, line) => {
+        if (line === '') {
+          return env
+        }
         const match = line.match(ENV_LINE_REGEX)
         if (!match) {
           if (!line.startsWith('#')) {

--- a/src/arguments.ts
+++ b/src/arguments.ts
@@ -30,7 +30,14 @@ function throwMissingEnvVar(name: string): never {
 }
 
 const ENV_LINE_REGEX = /^(\w+)=(.*)$/
+const TIMEOUT_INPUT_REGEX = /^\d+$/
 const MAX_TIMEOUT_SECONDS = 24 * 60 * 60
+
+function invalidTimeoutError(input: string): Error {
+  return new Error(
+    `Invalid timeout value: ${input} (expected an integer number of seconds between 1 and ${MAX_TIMEOUT_SECONDS}, or 0 to disable)`
+  )
+}
 
 function redactValue(line: string): string {
   const equalsIndex = line.indexOf('=')
@@ -91,17 +98,18 @@ export function processArguments(): Arguments {
   const timeoutInput = core.getInput('timeout')
   let timeout: number | undefined = undefined
   if (timeoutInput) {
-    const parsed = Number(timeoutInput)
-    if (
-      !Number.isSafeInteger(parsed) ||
-      parsed <= 0 ||
-      parsed > MAX_TIMEOUT_SECONDS
-    ) {
-      throw new Error(
-        `Invalid timeout value: ${timeoutInput} (expected an integer number of seconds between 1 and ${MAX_TIMEOUT_SECONDS})`
-      )
+    if (!TIMEOUT_INPUT_REGEX.test(timeoutInput.trim())) {
+      throw invalidTimeoutError(timeoutInput)
     }
-    timeout = parsed
+    const parsed = Number(timeoutInput)
+    if (parsed === 0) {
+      // 0 means "no timeout", for backwards compatibility with v2.
+      timeout = undefined
+    } else if (!Number.isSafeInteger(parsed) || parsed > MAX_TIMEOUT_SECONDS) {
+      throw invalidTimeoutError(timeoutInput)
+    } else {
+      timeout = parsed
+    }
   }
   const logFile = core.getInput('logFile') || undefined
   const quiet = core.getBooleanInput('quiet', { required: false })


### PR DESCRIPTION
Two silent input failures became loud ones.

A `setEnv` line that does not parse as `KEY=value` (dash in the key, multi-line value) was dropped without a word, so the app deployed missing a variable and nobody knew until production. It now emits a warning. The value is redacted (`KEY=***`), and a line with no `=` at all never has its content echoed. Whitespace-only lines are skipped silently.

`timeout` now accepts plain digits only, between 1 and 86400 seconds (24h cap), with `0` keeping its v2 meaning of "no timeout". Everything else fails the action with a clear message instead of being silently reinterpreted: `-5` used to arm an instant-kill timer that reported success, `12abc` parsed as 12, and `1e3` parsed as 1 second, killing slow deploys while showing green. Note the behavior change: garbage values (`nope`, `5.5`, `1e3`, `0x10`) used to mean "no timeout" or a mangled number and now fail the run.

Plan 005 from the advisor audit, hardened after a breaking-change review round.
