### PR TITLE
docs: add CLAUDE.md agent map

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,14 +10,6 @@ Docker action: users run a prebuilt image, NOT the code on master.
 - Build: `pnpm build` (`tsdown` -> `dist/`, gitignored — never commit `dist`)
 - Dead code: `pnpm knip`
 
-## Layout
-
-- `src/main.ts` entry: `git safe.directory` fix, arg parsing, `run()`
-- `src/arguments.ts` inputs from `INPUT_*` env + `CLEVER_TOKEN`/`CLEVER_SECRET`
-- `src/action.ts` `run()`: clever-tools calls; output tee (annotations, quiet, `logFile`)
-- `*.test.ts` co-located vitest; `action.test.ts` mocks `@actions/*`,
-  `arguments.test.ts` deliberately drives the real `@actions/core` via `INPUT_*` env vars — don't add mocks there
-
 ## Auth
 
 No `clever login` call. `CLEVER_TOKEN`/`CLEVER_SECRET` are read directly from

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ GitHub Action deploying to Clever Cloud by driving the clever-tools CLI.
 Docker action: users run a prebuilt image, NOT the code on master.
 
 ## Commands
-- Install: pnpm install --ignore-scripts   (pnpm 11 via corepack, Node 24.9)
+- Install: pnpm install --ignore-scripts   (pnpm version: packageManager in package.json; Node version: .node-version)
 - Test + typecheck: CI=true pnpm test      (vitest --typecheck; no separate tsc/lint script)
 - Build: pnpm build                        (tsdown -> dist/, gitignored — never commit dist)
 - Dead code: pnpm knip
@@ -13,7 +13,8 @@ Docker action: users run a prebuilt image, NOT the code on master.
 - src/main.ts       entry: git safe.directory fix, arg parsing, run()
 - src/arguments.ts  inputs from INPUT_* env + CLEVER_TOKEN/CLEVER_SECRET
 - src/action.ts     run(): clever-tools calls; output tee (annotations, quiet, logFile)
-- *.test.ts         co-located vitest; @actions/* mocked at module top
+- *.test.ts         co-located vitest; action.test.ts mocks @actions/*,
+                    arguments.test.ts deliberately drives the real @actions/core via INPUT_* env vars — don't add mocks there
 
 ## Auth
 No `clever login` call. CLEVER_TOKEN/CLEVER_SECRET are read directly from
@@ -21,11 +22,15 @@ env by clever-tools (its virtual "$env" profile) — set them as job secrets.
 
 ## Release coupling (easy to get wrong)
 - action.yml runs.image tag MUST equal package.json version (CI enforces).
-- Bump both together. `@master` does not run master code; Docker image does.
+- Bump both together. Referencing `@master` still runs the pinned Docker
+  image from action.yml, not the checked-out source.
 
 ## CI security invariants (do not weaken)
 - All workflows: top-level `permissions: {}`, jobs opt in minimally.
-- Never interpolate `${{ }}` into run: scripts — pass via env: (see pr-preview-manual.yml).
+- Never interpolate attacker-controllable values (PR titles/bodies/branch
+  names, fork data, workflow inputs) into run: scripts — pass via env:
+  (see pr-preview-manual.yml). Trusted server-side values (github.sha,
+  push-event ref_name, own-step outputs) may appear inline.
 - Fork PRs never get secrets; manual preview workflow is the vetted-fork path.
 
 ## Conventions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,33 @@
+# actions-clever-cloud
+
+GitHub Action deploying to Clever Cloud by driving the clever-tools CLI.
+Docker action: users run a prebuilt image, NOT the code on master.
+
+## Commands
+- Install: pnpm install --ignore-scripts   (pnpm 11 via corepack, Node 24.9)
+- Test + typecheck: CI=true pnpm test      (vitest --typecheck; no separate tsc/lint script)
+- Build: pnpm build                        (tsdown -> dist/, gitignored — never commit dist)
+- Dead code: pnpm knip
+
+## Layout
+- src/main.ts       entry: git safe.directory fix, arg parsing, run()
+- src/arguments.ts  inputs from INPUT_* env + CLEVER_TOKEN/CLEVER_SECRET
+- src/action.ts     run(): clever-tools calls; output tee (annotations, quiet, logFile)
+- *.test.ts         co-located vitest; @actions/* mocked at module top
+
+## Auth
+No `clever login` call. CLEVER_TOKEN/CLEVER_SECRET are read directly from
+env by clever-tools (its virtual "$env" profile) — set them as job secrets.
+
+## Release coupling (easy to get wrong)
+- action.yml runs.image tag MUST equal package.json version (CI enforces).
+- Bump both together. `@master` does not run master code; Docker image does.
+
+## CI security invariants (do not weaken)
+- All workflows: top-level `permissions: {}`, jobs opt in minimally.
+- Never interpolate `${{ }}` into run: scripts — pass via env: (see pr-preview-manual.yml).
+- Fork PRs never get secrets; manual preview workflow is the vetted-fork path.
+
+## Conventions
+- Conventional commits (fix:/feat:/chore:/docs:).
+- Prettier config in package.json; no semicolons, single quotes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,35 +4,41 @@ GitHub Action deploying to Clever Cloud by driving the clever-tools CLI.
 Docker action: users run a prebuilt image, NOT the code on master.
 
 ## Commands
-- Install: pnpm install --ignore-scripts   (pnpm version: packageManager in package.json; Node version: .node-version)
-- Test + typecheck: CI=true pnpm test      (vitest --typecheck; no separate tsc/lint script)
-- Build: pnpm build                        (tsdown -> dist/, gitignored — never commit dist)
-- Dead code: pnpm knip
+
+- Install: `pnpm install --ignore-scripts` (`pnpm` version: `packageManager` in `package.json`; Node version: `.node-version`)
+- Test + typecheck: `CI=true pnpm test` (`vitest --typecheck`; no separate `tsc`/lint script)
+- Build: `pnpm build` (`tsdown` -> `dist/`, gitignored — never commit `dist`)
+- Dead code: `pnpm knip`
 
 ## Layout
-- src/main.ts       entry: git safe.directory fix, arg parsing, run()
-- src/arguments.ts  inputs from INPUT_* env + CLEVER_TOKEN/CLEVER_SECRET
-- src/action.ts     run(): clever-tools calls; output tee (annotations, quiet, logFile)
-- *.test.ts         co-located vitest; action.test.ts mocks @actions/*,
-                    arguments.test.ts deliberately drives the real @actions/core via INPUT_* env vars — don't add mocks there
+
+- `src/main.ts` entry: `git safe.directory` fix, arg parsing, `run()`
+- `src/arguments.ts` inputs from `INPUT_*` env + `CLEVER_TOKEN`/`CLEVER_SECRET`
+- `src/action.ts` `run()`: clever-tools calls; output tee (annotations, quiet, `logFile`)
+- `*.test.ts` co-located vitest; `action.test.ts` mocks `@actions/*`,
+  `arguments.test.ts` deliberately drives the real `@actions/core` via `INPUT_*` env vars — don't add mocks there
 
 ## Auth
-No `clever login` call. CLEVER_TOKEN/CLEVER_SECRET are read directly from
-env by clever-tools (its virtual "$env" profile) — set them as job secrets.
+
+No `clever login` call. `CLEVER_TOKEN`/`CLEVER_SECRET` are read directly from
+env by clever-tools (its virtual `$env` profile) — set them as job secrets.
 
 ## Release coupling (easy to get wrong)
-- action.yml runs.image tag MUST equal package.json version (CI enforces).
+
+- `action.yml` `runs.image` tag MUST equal `package.json` version (CI enforces).
 - Bump both together. Referencing `@master` still runs the pinned Docker
-  image from action.yml, not the checked-out source.
+  image from `action.yml`, not the checked-out source.
 
 ## CI security invariants (do not weaken)
+
 - All workflows: top-level `permissions: {}`, jobs opt in minimally.
 - Never interpolate attacker-controllable values (PR titles/bodies/branch
-  names, fork data, workflow inputs) into run: scripts — pass via env:
-  (see pr-preview-manual.yml). Trusted server-side values (github.sha,
-  push-event ref_name, own-step outputs) may appear inline.
+  names, fork data, workflow inputs) into `run:` scripts — pass via `env:`
+  (see `pr-preview-manual.yml`). Trusted server-side values (`github.sha`,
+  push-event `ref_name`, own-step outputs) may appear inline.
 - Fork PRs never get secrets; manual preview workflow is the vetted-fork path.
 
 ## Conventions
+
 - Conventional commits (fix:/feat:/chore:/docs:).
 - Prettier config in package.json; no semicolons, single quotes.


### PR DESCRIPTION
Every agent session on this repo re-derives the same facts: pnpm not npm, tests carry the typecheck, dist is build output and never committed, and the action.yml image tag must move in lockstep with package.json. This 33-line map ends that repeated discovery and calls out the mistakes worth preventing (committing dist, bumping only one version location, weakening the workflow permission model).

Written against the state after the other advisor PRs land (no ESLint mention, env-based auth), so it reads correctly once the batch is merged.

Plan 011 from the advisor audit.
