### PR TITLE
doc: update README examples to v2.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ steps:
       fetch-depth: 0
 
   # Deploy your application
-  - uses: 47ng/actions-clever-cloud@v2.1.2
+  - uses: 47ng/actions-clever-cloud@v2.1.3
     env:
       CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
       CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
@@ -63,7 +63,7 @@ the alias of the application to deploy:
 
 <!-- x-release-please-start-version -->
 ```yml
-- uses: 47ng/actions-clever-cloud@v2.1.2
+- uses: 47ng/actions-clever-cloud@v2.1.3
   with:
     alias: my-app-alias
   env:
@@ -77,7 +77,7 @@ deploy to another application, you can pass its ID:
 
 <!-- x-release-please-start-version -->
 ```yml
-- uses: 47ng/actions-clever-cloud@v2.1.2
+- uses: 47ng/actions-clever-cloud@v2.1.3
   with:
     appID: app_facade42-cafe-babe-cafe-deadf00dbaad
   env:
@@ -122,7 +122,7 @@ key=value).
 
 <!-- x-release-please-start-version -->
 ```yml
-- uses: 47ng/actions-clever-cloud@v2.1.2
+- uses: 47ng/actions-clever-cloud@v2.1.3
   with:
     setEnv: | # <- note the pipe here..
       FOO=bar
@@ -164,7 +164,7 @@ regardless of the deployment status:
 
 <!-- x-release-please-start-version -->
 ```yml
-- uses: 47ng/actions-clever-cloud@v2.1.2
+- uses: 47ng/actions-clever-cloud@v2.1.3
   with:
     timeout: 1800 # wait at maximum 30 minutes before moving on
   env:
@@ -181,7 +181,7 @@ Clever Cloud uses a Git remote to perform deploys. By default, if the commit you
 
 <!-- x-release-please-start-version -->
 ```yml
-- uses: 47ng/actions-clever-cloud@v2.1.2
+- uses: 47ng/actions-clever-cloud@v2.1.3
   with:
     appID: app_facade42-cafe-babe-cafe-deadf00dbaad
     force: true
@@ -202,7 +202,7 @@ Clever Cloud receives the whole Git repository. To deploy one app from a monorep
 
 <!-- x-release-please-start-version -->
 ```yml
-- uses: 47ng/actions-clever-cloud@v2.1.2
+- uses: 47ng/actions-clever-cloud@v2.1.3
   with:
     alias: backend
     setEnv: |
@@ -238,7 +238,7 @@ When the local and remote commits are identical, you can control what happens us
 
 <!-- x-release-please-start-version -->
 ```yml
-- uses: 47ng/actions-clever-cloud@v2.1.2
+- uses: 47ng/actions-clever-cloud@v2.1.3
   with:
     sameCommitPolicy: restart
   env:
@@ -255,7 +255,7 @@ You can write the deployment logs to a file for archiving:
 
 <!-- x-release-please-start-version -->
 ```yml
-- uses: 47ng/actions-clever-cloud@v2.1.2
+- uses: 47ng/actions-clever-cloud@v2.1.3
   with:
     logFile: ./clever-cloud-deploy.log
   env:
@@ -276,7 +276,7 @@ disable it from printing onto the console, using the `quiet` option:
 
 <!-- x-release-please-start-version -->
 ```yml
-- uses: 47ng/actions-clever-cloud@v2.1.2
+- uses: 47ng/actions-clever-cloud@v2.1.3
   with:
     quiet: true
   env:
@@ -299,7 +299,7 @@ This action follows [SemVer](https://semver.org/).
 
 To specify the version of the action to use:
 
-- `uses: 47ng/actions-clever-cloud@v2.1.2`: latest stable version <!-- x-release-please-version -->
+- `uses: 47ng/actions-clever-cloud@v2.1.3`: latest stable version <!-- x-release-please-version -->
 - `uses: 47ng/actions-clever-cloud@f496297399b2351f4459d10f556e1c4eff2566b7`: pinned to a specific Git SHA-1 (check out the [releases](https://github.com/47ng/actions-clever-cloud/releases))
 - `uses: docker://ghcr.io/47ng/actions-clever-cloud:latest`: latest code from master (not recommended, as it may break: hic sunt dracones.)
 


### PR DESCRIPTION
## Summary

- update all 11 README action references from v2.1.2 to v2.1.3
- preserve the hidden Release Please updater fences added after the existing v2.1.3 release PR was generated

## Checks

- confirmed all documented action references match package version 2.1.3
- rendered through GitHub’s Markdown API and confirmed updater comments remain invisible