### PR TITLE
fix: fail signal-terminated deployments

### DIFF
--- a/src/action.test.ts
+++ b/src/action.test.ts
@@ -413,6 +413,25 @@ test('deploy fails before timeout: fails the workflow', async () => {
   expect(setFailed).toHaveBeenCalledWith('Deployment failed with code 42')
 })
 
+test('deploy terminated by a signal before timeout fails the workflow', async () => {
+  vi.useFakeTimers()
+  const child = makeFakeChild()
+  spawnMock.mockReturnValue(child)
+  const finished = run({
+    token: 'token',
+    secret: 'secret',
+    cleverCLI: CLEVER_CLI,
+    timeout: 1800
+  })
+  await vi.advanceTimersByTimeAsync(1000)
+  child.emit('close', null, 'SIGTERM')
+  await finished
+  expect(child.kill).not.toHaveBeenCalled()
+  expect(setFailed).toHaveBeenCalledWith(
+    'Deployment terminated by signal SIGTERM'
+  )
+})
+
 test('spawn error: fails the workflow and leaves no pending timer', async () => {
   vi.useFakeTimers()
   const child = makeFakeChild()

--- a/src/action.ts
+++ b/src/action.ts
@@ -249,7 +249,13 @@ function spawnDeploy(
   }
   const exited = new Promise<number>((resolve, reject) => {
     child.once('error', reject)
-    child.once('close', code => resolve(code ?? 0))
+    child.once('close', (code, signal) => {
+      if (signal) {
+        reject(new Error(`Deployment terminated by signal ${signal}`))
+      } else {
+        resolve(code ?? 0)
+      }
+    })
   })
   return { child, exited }
 }


### PR DESCRIPTION
## Summary

Fail timeout-mode deployments when the Clever CLI exits due to an external signal. Signal exits have no numeric exit code, so treating a missing code as zero incorrectly reported success. The action-owned timeout path still moves on without failing.