### PR TITLE
fix: accept Clever-compatible environment names

### DIFF
--- a/src/arguments.test.ts
+++ b/src/arguments.test.ts
@@ -82,13 +82,17 @@ test('extra env, Clever-compatible dotted and dashed keys are accepted', () => {
   expect(warn).not.toHaveBeenCalled()
 })
 
-test('extra env, __proto__ is preserved as an own property', () => {
-  process.env.INPUT_SETENV = '__proto__=sentinel'
+test('extra env, __proto__ key is rejected with a redacted warning', () => {
+  process.env.INPUT_SETENV = '__proto__=super-secret'
   process.env.CLEVER_TOKEN = 'token'
   process.env.CLEVER_SECRET = 'secret'
   const args = processArguments()
-  expect(Object.entries(args.extraEnv!)).toEqual([['__proto__', 'sentinel']])
-  expect(warn).not.toHaveBeenCalled()
+  expect(args.extraEnv).toBeDefined()
+  expect(Object.hasOwn(args.extraEnv!, '__proto__')).toBe(false)
+  expect(warn).toHaveBeenCalledTimes(1)
+  const message = warn.mock.calls[0]![0] as string
+  expect(message).not.toContain('super-secret')
+  expect(message).toContain('__proto__=***')
 })
 
 test('extra env, invalid key is dropped with a warning that redacts the value', () => {

--- a/src/arguments.test.ts
+++ b/src/arguments.test.ts
@@ -71,17 +71,28 @@ test('extra env', () => {
   expect(warn).not.toHaveBeenCalled()
 })
 
-test('extra env, dash key is dropped with a warning that redacts the value', () => {
-  process.env.INPUT_SETENV = 'MY-VAR=super-secret'
+test('extra env, Clever-compatible dotted and dashed keys are accepted', () => {
+  process.env.INPUT_SETENV = 'MY-VAR=dashed\nMY.DOT=dotted'
   process.env.CLEVER_TOKEN = 'token'
   process.env.CLEVER_SECRET = 'secret'
   const args = processArguments()
   expect(args.extraEnv).toBeDefined()
-  expect(args.extraEnv!['MY-VAR']).toBeUndefined()
+  expect(args.extraEnv!['MY-VAR']).toEqual('dashed')
+  expect(args.extraEnv!['MY.DOT']).toEqual('dotted')
+  expect(warn).not.toHaveBeenCalled()
+})
+
+test('extra env, invalid key is dropped with a warning that redacts the value', () => {
+  process.env.INPUT_SETENV = 'MY/VAR=super-secret'
+  process.env.CLEVER_TOKEN = 'token'
+  process.env.CLEVER_SECRET = 'secret'
+  const args = processArguments()
+  expect(args.extraEnv).toBeDefined()
+  expect(args.extraEnv!['MY/VAR']).toBeUndefined()
   expect(warn).toHaveBeenCalledTimes(1)
   const message = warn.mock.calls[0]![0] as string
   expect(message).not.toContain('super-secret')
-  expect(message).toContain('MY-VAR=***')
+  expect(message).toContain('MY/VAR=***')
 })
 
 test('extra env, line without = never echoes its content', () => {

--- a/src/arguments.test.ts
+++ b/src/arguments.test.ts
@@ -82,6 +82,15 @@ test('extra env, Clever-compatible dotted and dashed keys are accepted', () => {
   expect(warn).not.toHaveBeenCalled()
 })
 
+test('extra env, __proto__ is preserved as an own property', () => {
+  process.env.INPUT_SETENV = '__proto__=sentinel'
+  process.env.CLEVER_TOKEN = 'token'
+  process.env.CLEVER_SECRET = 'secret'
+  const args = processArguments()
+  expect(Object.entries(args.extraEnv!)).toEqual([['__proto__', 'sentinel']])
+  expect(warn).not.toHaveBeenCalled()
+})
+
 test('extra env, invalid key is dropped with a warning that redacts the value', () => {
   process.env.INPUT_SETENV = 'MY/VAR=super-secret'
   process.env.CLEVER_TOKEN = 'token'

--- a/src/arguments.ts
+++ b/src/arguments.ts
@@ -29,7 +29,7 @@ function throwMissingEnvVar(name: string): never {
   )
 }
 
-const ENV_LINE_REGEX = /^(\w+)=(.*)$/
+const ENV_LINE_REGEX = /^([a-zA-Z0-9-_.]+)=(.*)$/
 const TIMEOUT_INPUT_REGEX = /^\d+$/
 const MAX_TIMEOUT_SECONDS = 24 * 60 * 60
 
@@ -60,7 +60,7 @@ function listExtraEnv(): ExtraEnv {
         if (!match) {
           if (!line.startsWith('#')) {
             core.warning(
-              `Ignoring setEnv line that is not KEY=value (keys are [A-Za-z0-9_]): ${redactValue(line)}`
+              `Ignoring setEnv line that is not KEY=value (keys are [A-Za-z0-9_.-]): ${redactValue(line)}`
             )
           }
           return env

--- a/src/arguments.ts
+++ b/src/arguments.ts
@@ -70,7 +70,7 @@ function listExtraEnv(): ExtraEnv {
         env[key] = value
         return env
       },
-      {} as Record<string, string>
+      Object.create(null) as Record<string, string>
     )
 
   if (Object.keys(extraEnv).length) {

--- a/src/arguments.ts
+++ b/src/arguments.ts
@@ -67,10 +67,16 @@ function listExtraEnv(): ExtraEnv {
         }
         const key = match[1]!
         const value = match[2]!
+        if (key === '__proto__') {
+          core.warning(
+            `Ignoring setEnv line with reserved key: ${redactValue(line)}`
+          )
+          return env
+        }
         env[key] = value
         return env
       },
-      Object.create(null) as Record<string, string>
+      {} as Record<string, string>
     )
 
   if (Object.keys(extraEnv).length) {

--- a/src/arguments.ts
+++ b/src/arguments.ts
@@ -69,7 +69,7 @@ function listExtraEnv(): ExtraEnv {
         const value = match[2]!
         if (key === '__proto__') {
           core.warning(
-            `Ignoring setEnv line with reserved key: ${redactValue(line)}`
+            `Ignoring setEnv line with key: ${redactValue(line)}`
           )
           return env
         }


### PR DESCRIPTION
## Summary

Accept Clever Cloud environment variable names containing dots and dashes so valid `setEnv` entries are no longer silently dropped. Invalid entries remain ignored, with their values redacted from warnings.