### PR TITLE
fix: make appID linking idempotent

### DIFF
--- a/src/action.test.ts
+++ b/src/action.test.ts
@@ -62,7 +62,18 @@ function makeFakeChild() {
 beforeEach(() => {
   vi.clearAllMocks()
   // Reset to default success behavior
-  execMock.mockResolvedValue(0)
+  execMock.mockImplementation(
+    (
+      _cli: string,
+      args: string[],
+      options?: { listeners?: { stdout?: (data: Buffer) => void } }
+    ) => {
+      if (args[0] === 'applications') {
+        options?.listeners?.stdout?.(Buffer.from('[]\n'))
+      }
+      return Promise.resolve(0)
+    }
+  )
 })
 
 afterEach(() => {
@@ -115,17 +126,123 @@ test('deploy application with app ID', async () => {
     cleverCLI: CLEVER_CLI
   })
   expectCleverCLICallWithArgs(
-    1,
+    2,
     'link',
     'app_facade42-cafe-babe-cafe-deadf00dbaad',
     '--alias',
     'app_facade42-cafe-babe-cafe-deadf00dbaad'
   )
   expectCleverCLICallWithArgs(
-    2,
+    3,
     'deploy',
     '--alias',
     'app_facade42-cafe-babe-cafe-deadf00dbaad'
+  )
+})
+
+test('reuses an existing app link with the requested alias', async () => {
+  const appID = 'app_facade42-cafe-babe-cafe-deadf00dbaad'
+  execMock.mockImplementation(
+    (
+      _cli: string,
+      args: string[],
+      options?: { listeners?: { stdout?: (data: Buffer) => void } }
+    ) => {
+      if (args[0] === 'applications') {
+        options?.listeners?.stdout?.(
+          Buffer.from(JSON.stringify([{ app_id: appID, alias: appID }]))
+        )
+        return Promise.resolve(0)
+      }
+      if (args[0] === 'link') {
+        return Promise.reject(
+          new Error(
+            `Application ${appID} is already linked with alias ${appID}`
+          )
+        )
+      }
+      return Promise.resolve(0)
+    }
+  )
+
+  await run({
+    token: 'token',
+    secret: 'secret',
+    appID,
+    cleverCLI: CLEVER_CLI
+  })
+
+  expect(execMock.mock.calls.some(call => call[1]?.[0] === 'link')).toBe(false)
+  expectCleverCLICallWithArgs(2, 'deploy', '--alias', appID)
+  expect(setFailed).not.toHaveBeenCalled()
+})
+
+test('reuses a pre-existing alias for an app that is already linked', async () => {
+  const appID = 'app_facade42-cafe-babe-cafe-deadf00dbaad'
+  execMock.mockImplementation(
+    (
+      _cli: string,
+      args: string[],
+      options?: { listeners?: { stdout?: (data: Buffer) => void } }
+    ) => {
+      if (args[0] === 'applications') {
+        options?.listeners?.stdout?.(
+          Buffer.from(JSON.stringify([{ app_id: appID, alias: 'review-app' }]))
+        )
+        return Promise.resolve(0)
+      }
+      if (args[0] === 'link') {
+        return Promise.reject(
+          new Error(
+            `Application ${appID} is already linked with alias review-app`
+          )
+        )
+      }
+      return Promise.resolve(0)
+    }
+  )
+
+  await run({
+    token: 'token',
+    secret: 'secret',
+    appID,
+    cleverCLI: CLEVER_CLI
+  })
+
+  expect(execMock.mock.calls.some(call => call[1]?.[0] === 'link')).toBe(false)
+  expectCleverCLICallWithArgs(2, 'deploy', '--alias', 'review-app')
+  expect(setFailed).not.toHaveBeenCalled()
+})
+
+test('does not swallow unrelated link failures', async () => {
+  const appID = 'app_facade42-cafe-babe-cafe-deadf00dbaad'
+  execMock.mockImplementation(
+    (
+      _cli: string,
+      args: string[],
+      options?: { listeners?: { stdout?: (data: Buffer) => void } }
+    ) => {
+      if (args[0] === 'applications') {
+        options?.listeners?.stdout?.(Buffer.from('[]'))
+        return Promise.resolve(0)
+      }
+      if (args[0] === 'link') {
+        return Promise.reject(new Error('Clever API is unavailable'))
+      }
+      return Promise.resolve(0)
+    }
+  )
+
+  await run({
+    token: 'token',
+    secret: 'secret',
+    appID,
+    cleverCLI: CLEVER_CLI
+  })
+
+  expect(setFailed).toHaveBeenCalledWith('Clever API is unavailable')
+  expect(execMock.mock.calls.some(call => call[1]?.[0] === 'deploy')).toBe(
+    false
   )
 })
 
@@ -138,14 +255,14 @@ test('when both app ID and alias are provided, appID takes precedence', async ()
     cleverCLI: CLEVER_CLI
   })
   expectCleverCLICallWithArgs(
-    1,
+    2,
     'link',
     'app_facade42-cafe-babe-cafe-deadf00dbaad',
     '--alias',
     'app_facade42-cafe-babe-cafe-deadf00dbaad'
   )
   expectCleverCLICallWithArgs(
-    2,
+    3,
     'deploy',
     '--alias',
     'app_facade42-cafe-babe-cafe-deadf00dbaad'
@@ -183,14 +300,14 @@ test('passing extra env variables, using appID', async () => {
     }
   })
   expectCleverCLICallWithArgs(
-    1,
+    2,
     'link',
     'app_facade42-cafe-babe-cafe-deadf00dbaad',
     '--alias',
     'app_facade42-cafe-babe-cafe-deadf00dbaad'
   )
   expectCleverCLICallWithArgs(
-    2,
+    3,
     'env',
     'set',
     '--alias',
@@ -199,7 +316,7 @@ test('passing extra env variables, using appID', async () => {
     'bar'
   )
   expectCleverCLICallWithArgs(
-    3,
+    4,
     'env',
     'set',
     '--alias',
@@ -208,7 +325,7 @@ test('passing extra env variables, using appID', async () => {
     'spam'
   )
   expectCleverCLICallWithArgs(
-    4,
+    5,
     'deploy',
     '--alias',
     'app_facade42-cafe-babe-cafe-deadf00dbaad'
@@ -441,14 +558,14 @@ test('force deploy application', async () => {
     force: true
   })
   expectCleverCLICallWithArgs(
-    1,
+    2,
     'link',
     'app_facade42-cafe-babe-cafe-deadf00dbaad',
     '--alias',
     'app_facade42-cafe-babe-cafe-deadf00dbaad'
   )
   expectCleverCLICallWithArgs(
-    2,
+    3,
     'deploy',
     '--alias',
     'app_facade42-cafe-babe-cafe-deadf00dbaad',

--- a/src/action.ts
+++ b/src/action.ts
@@ -27,6 +27,49 @@ async function checkForShallowCopy(): Promise<void> {
   }
 }
 
+async function getLinkedAppAlias(
+  cleverCLI: string,
+  appID: string,
+  execOptions: ExecOptions
+): Promise<string | undefined> {
+  let stdout = ''
+  await exec(cleverCLI, ['applications', '--json'], {
+    ...execOptions,
+    silent: true,
+    listeners: {
+      stdout: (data: Buffer) => (stdout += data.toString())
+    }
+  })
+
+  let applications: unknown
+  try {
+    applications = JSON.parse(stdout)
+  } catch {
+    throw new Error('Clever CLI returned invalid linked application data')
+  }
+  if (!Array.isArray(applications)) {
+    throw new Error('Clever CLI returned invalid linked application data')
+  }
+
+  const linkedApplication = applications.find(
+    (application): application is { app_id: string; alias?: unknown } =>
+      typeof application === 'object' &&
+      application !== null &&
+      'app_id' in application &&
+      application.app_id === appID
+  )
+  if (!linkedApplication) {
+    return undefined
+  }
+  if (
+    typeof linkedApplication.alias !== 'string' ||
+    linkedApplication.alias.length === 0
+  ) {
+    throw new Error(`Application ${appID} is linked without a valid alias`)
+  }
+  return linkedApplication.alias
+}
+
 export async function run({
   appID,
   alias,
@@ -64,13 +107,19 @@ export async function run({
     // environment variables (virtual "$env" profile); no login call needed.
 
     // There is an issue when there is a .clever.json file present
-    // and only the appID is passed: link will work, but deploy will need
-    // an alias to know which app to publish. In this case, we set the alias
-    // to the appID, and the alias argument is ignored if also specified.
+    // and only the appID is passed: deploy needs an alias to know which app
+    // to publish. Reuse an existing link when possible; clever link rejects
+    // duplicate app IDs, including when they use a different alias.
     if (appID) {
-      core.debug(`Linking ${appID}`)
-      await exec(cleverCLI, ['link', appID, '--alias', appID], execOptions)
-      alias = appID
+      const linkedAlias = await getLinkedAppAlias(cleverCLI, appID, execOptions)
+      if (linkedAlias) {
+        core.debug(`Application ${appID} is already linked as ${linkedAlias}`)
+        alias = linkedAlias
+      } else {
+        core.debug(`Linking ${appID}`)
+        await exec(cleverCLI, ['link', appID, '--alias', appID], execOptions)
+        alias = appID
+      }
     }
 
     // If there are environment variables to pass to the application,
@@ -105,9 +154,7 @@ export async function run({
     }
 
     const args = ['deploy']
-    if (appID) {
-      args.push('--alias', appID)
-    } else if (alias) {
+    if (alias) {
       args.push('--alias', alias)
     }
 


### PR DESCRIPTION
## Summary

- Check existing Clever application links before linking an `appID`
- Reuse the linked alias when the same application is already present

## Rationale

This avoids unlink/relink side effects while allowing unrelated link failures to surface normally.

Closes #222