### PR TITLE
fix: detect no-property workflow commands

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -320,19 +320,13 @@ export async function getOutputStream(
         // Remove timestamp, if present
         const message = line.replace(TIMESTAMP_PREFIX_REGEX, '')
         // Only re-emit when a timestamp was actually stripped: a line that
-        // already starts with ::notice/::error/::warning at column 0 (no
-        // timestamp) is echoed above as-is, and the runner parses workflow
-        // commands at line start on its own — re-emitting it here would
-        // duplicate the annotation.
-        if (
-          message !== line &&
-          (message.startsWith('::notice ') ||
-            message.startsWith('::notice::') ||
-            message.startsWith('::error ') ||
-            message.startsWith('::error::') ||
-            message.startsWith('::warning ') ||
-            message.startsWith('::warning::'))
-        ) {
+        // already contains a runner-recognized workflow command (without a
+        // timestamp) is echoed above as-is, and the runner parses it on its
+        // own. Re-emitting it here would duplicate the annotation.
+        const isAnnotation = /^::(?:notice|error|warning)(?:::| .*::)/i.test(
+          message.trimStart()
+        )
+        if (message !== line && isAnnotation) {
           yield message + lineSeparator
         }
       }

--- a/src/action.ts
+++ b/src/action.ts
@@ -327,8 +327,11 @@ export async function getOutputStream(
         if (
           message !== line &&
           (message.startsWith('::notice ') ||
+            message.startsWith('::notice::') ||
             message.startsWith('::error ') ||
-            message.startsWith('::warning '))
+            message.startsWith('::error::') ||
+            message.startsWith('::warning ') ||
+            message.startsWith('::warning::'))
         ) {
           yield message + lineSeparator
         }

--- a/src/output-stream.test.ts
+++ b/src/output-stream.test.ts
@@ -80,6 +80,33 @@ test.each(['notice', 'error', 'warning'])(
   }
 )
 
+test('non-quiet: command names are matched case-insensitively', async () => {
+  const { stream, done } = await getOutputStream(false)
+  stream.write(`${TS}::ERROR::Deployed!\n`)
+  stream.end()
+  await done()
+  const out = capturedStdout()
+  expect(out.split('::ERROR::Deployed!').length - 1).toBe(2)
+})
+
+test('non-quiet: leading command whitespace is tolerated', async () => {
+  const { stream, done } = await getOutputStream(false)
+  stream.write(`${TS} ::error::Deployed!\n`)
+  stream.end()
+  await done()
+  const out = capturedStdout()
+  expect(out.split('::error::Deployed!').length - 1).toBe(2)
+})
+
+test('non-quiet: a property command without a closing delimiter is not re-emitted', async () => {
+  const { stream, done } = await getOutputStream(false)
+  stream.write(`${TS}::error title=Deploy failed\n`)
+  stream.end()
+  await done()
+  const out = capturedStdout()
+  expect(out.split('::error title=Deploy failed').length - 1).toBe(1)
+})
+
 test('non-quiet: non-annotation lines are not re-emitted', async () => {
   const { stream, done } = await getOutputStream(false)
   stream.write(TS + 'plain\n')

--- a/src/output-stream.test.ts
+++ b/src/output-stream.test.ts
@@ -67,6 +67,19 @@ test.each(['notice', 'error', 'warning'])(
   }
 )
 
+test.each(['notice', 'error', 'warning'])(
+  'non-quiet: no-property ::%s commands are re-emitted without their timestamp',
+  async kind => {
+    const { stream, done } = await getOutputStream(false)
+    stream.write(`${TS}::${kind}::Deployed!\n`)
+    stream.end()
+    await done()
+    const out = capturedStdout()
+    const occurrences = out.split(`::${kind}::Deployed!`).length - 1
+    expect(occurrences).toBe(2)
+  }
+)
+
 test('non-quiet: non-annotation lines are not re-emitted', async () => {
   const { stream, done } = await getOutputStream(false)
   stream.write(TS + 'plain\n')
@@ -183,6 +196,15 @@ test('non-quiet: a line without a timestamp prefix is not duplicated', async () 
   // already parses this workflow command from the raw, column-0 line.
   // Re-emitting it here would duplicate the annotation.
   expect(out.split('::error ::no-timestamp').length - 1).toBe(1)
+})
+
+test('non-quiet: a no-property command without a timestamp is not duplicated', async () => {
+  const { stream, done } = await getOutputStream(false)
+  stream.write('::error::no-timestamp\n')
+  stream.end()
+  await done()
+  const out = capturedStdout()
+  expect(out.split('::error::no-timestamp').length - 1).toBe(1)
 })
 
 test('non-quiet: a Clever CLI timestamp is stripped before annotation detection', async () => {


### PR DESCRIPTION
## Summary

Recognize timestamped `::notice::`, `::error::`, and `::warning::` workflow commands emitted without properties. Clever CLI timestamps keep the runner from parsing these commands directly, so the action now re-emits the stripped command while leaving untimestamped commands untouched.