### PR TITLE
fix: preserve setEnv value semantics

### DIFF
--- a/src/arguments.test.ts
+++ b/src/arguments.test.ts
@@ -104,6 +104,15 @@ test('extra env, whitespace-only line between valid vars is skipped without a wa
   expect(warn).not.toHaveBeenCalled()
 })
 
+test('extra env parses CRLF lines without changing their values', () => {
+  process.env.INPUT_SETENV = 'FIRST=one\r\nSECOND=two\r\n'
+  process.env.CLEVER_TOKEN = 'token'
+  process.env.CLEVER_SECRET = 'secret'
+  const args = processArguments()
+  expect(args.extraEnv).toEqual({ FIRST: 'one', SECOND: 'two' })
+  expect(warn).not.toHaveBeenCalled()
+})
+
 test('extra env preserves whitespace in unquoted values', () => {
   process.env.INPUT_SETENV = 'VALUE=  leading and trailing  '
   process.env.CLEVER_TOKEN = 'token'
@@ -119,6 +128,31 @@ test('extra env removes matching quote delimiters from values', () => {
   const args = processArguments()
   expect(args.extraEnv!.DOUBLE).toEqual(' quoted ')
   expect(args.extraEnv!.SINGLE).toEqual('quoted')
+})
+
+test('extra env unescapes matching quotes in quoted values', () => {
+  process.env.INPUT_SETENV = 'DOUBLE="say \\"hello\\""\nSINGLE=\'it\\\'s\''
+  process.env.CLEVER_TOKEN = 'token'
+  process.env.CLEVER_SECRET = 'secret'
+  const args = processArguments()
+  expect(args.extraEnv!.DOUBLE).toEqual('say "hello"')
+  expect(args.extraEnv!.SINGLE).toEqual("it's")
+})
+
+test('extra env drops malformed quoted values with redacted warnings', () => {
+  process.env.INPUT_SETENV =
+    'LONE="\nUNMATCHED="unterminated\nTRAILING="closed"tail\nESCAPED_END="ends\\"'
+  process.env.CLEVER_TOKEN = 'token'
+  process.env.CLEVER_SECRET = 'secret'
+  const args = processArguments()
+  expect(args.extraEnv).toEqual({})
+  expect(warn).toHaveBeenCalledTimes(4)
+  for (const [message] of warn.mock.calls) {
+    expect(message).not.toContain('unterminated')
+    expect(message).not.toContain('closed')
+    expect(message).not.toContain('ends')
+    expect(message).toContain('=***')
+  }
 })
 
 test('timeout, default value is undefined', () => {

--- a/src/arguments.test.ts
+++ b/src/arguments.test.ts
@@ -104,6 +104,23 @@ test('extra env, whitespace-only line between valid vars is skipped without a wa
   expect(warn).not.toHaveBeenCalled()
 })
 
+test('extra env preserves whitespace in unquoted values', () => {
+  process.env.INPUT_SETENV = 'VALUE=  leading and trailing  '
+  process.env.CLEVER_TOKEN = 'token'
+  process.env.CLEVER_SECRET = 'secret'
+  const args = processArguments()
+  expect(args.extraEnv!.VALUE).toEqual('  leading and trailing  ')
+})
+
+test('extra env removes matching quote delimiters from values', () => {
+  process.env.INPUT_SETENV = 'DOUBLE=" quoted "\nSINGLE=\'quoted\''
+  process.env.CLEVER_TOKEN = 'token'
+  process.env.CLEVER_SECRET = 'secret'
+  const args = processArguments()
+  expect(args.extraEnv!.DOUBLE).toEqual(' quoted ')
+  expect(args.extraEnv!.SINGLE).toEqual('quoted')
+})
+
 test('timeout, default value is undefined', () => {
   process.env.CLEVER_TOKEN = 'token'
   process.env.CLEVER_SECRET = 'secret'

--- a/src/arguments.ts
+++ b/src/arguments.ts
@@ -47,18 +47,36 @@ function redactValue(line: string): string {
   return `${line.slice(0, equalsIndex)}=***`
 }
 
-function parseEnvValue(value: string): string {
+function parseEnvValue(value: string): string | undefined {
   const quote = value[0]
-  if ((quote === '"' || quote === "'") && value.at(-1) === quote) {
-    return value.slice(1, -1)
+  if (quote !== '"' && quote !== "'") {
+    return value
   }
-  return value
+
+  let closingQuoteIndex = 1
+  let escaped = false
+  while (closingQuoteIndex < value.length) {
+    if (value[closingQuoteIndex] === quote && !escaped) {
+      break
+    }
+    escaped = value[closingQuoteIndex] === '\\'
+    closingQuoteIndex += 1
+  }
+  if (closingQuoteIndex !== value.length - 1) {
+    return undefined
+  }
+
+  const quotedValue = value.slice(1, closingQuoteIndex)
+  const quotePattern = quote === '"' ? /([\\]*)"/g : /([\\]*)'/g
+  return quotedValue.replace(quotePattern, (_, slashes: string) => {
+    return '\\'.repeat((slashes.length - 1) / 2) + quote
+  })
 }
 
 function listExtraEnv(): ExtraEnv {
   const extraEnv = core
     .getMultilineInput('setEnv', { trimWhitespace: false })
-    .map(line => line.trimStart())
+    .map(line => line.replace(/\r$/, '').trimStart())
     .reduce(
       (env, line) => {
         if (line === '') {
@@ -75,6 +93,12 @@ function listExtraEnv(): ExtraEnv {
         }
         const key = match[1]!
         const value = parseEnvValue(match[2]!)
+        if (value === undefined) {
+          core.warning(
+            `Ignoring setEnv line with invalid quotes: ${redactValue(line)}`
+          )
+          return env
+        }
         env[key] = value
         return env
       },

--- a/src/arguments.ts
+++ b/src/arguments.ts
@@ -47,10 +47,18 @@ function redactValue(line: string): string {
   return `${line.slice(0, equalsIndex)}=***`
 }
 
+function parseEnvValue(value: string): string {
+  const quote = value[0]
+  if ((quote === '"' || quote === "'") && value.at(-1) === quote) {
+    return value.slice(1, -1)
+  }
+  return value
+}
+
 function listExtraEnv(): ExtraEnv {
   const extraEnv = core
-    .getMultilineInput('setEnv')
-    .map(line => line.trim())
+    .getMultilineInput('setEnv', { trimWhitespace: false })
+    .map(line => line.trimStart())
     .reduce(
       (env, line) => {
         if (line === '') {
@@ -66,7 +74,7 @@ function listExtraEnv(): ExtraEnv {
           return env
         }
         const key = match[1]!
-        const value = match[2]!
+        const value = parseEnvValue(match[2]!)
         env[key] = value
         return env
       },


### PR DESCRIPTION
## Summary

- Preserve leading and trailing whitespace in `setEnv` values.
- Remove matching single or double quote delimiters from quoted values.

## Rationale

`setEnv` is documented as using `.env` syntax. This aligns parsed values with Clever Cloud semantics while leaving comments, blank lines, duplicate keys, and multiline limitations unchanged.