### PR TITLE
fix: apply backpressure to deploy output

### DIFF
--- a/src/action.test.ts
+++ b/src/action.test.ts
@@ -63,6 +63,15 @@ beforeEach(() => {
   vi.clearAllMocks()
   // Reset to default success behavior
   execMock.mockResolvedValue(0)
+  spawnMock.mockImplementation(() => {
+    const child = makeFakeChild()
+    setImmediate(() => {
+      child.stdout.end()
+      child.stderr.end()
+      child.emit('close', 0)
+    })
+    return child
+  })
 })
 
 afterEach(() => {
@@ -85,6 +94,15 @@ function expectCleverCLICallWithArgs(
   })
 }
 
+function expectDeploySpawnWithArgs(...expectedArgs: any[]) {
+  expect(spawnMock).toHaveBeenCalled()
+  const [cli, args] = spawnMock.mock.calls.at(-1) ?? []
+  expect(cli).toEqual(CLEVER_CLI)
+  expectedArgs.forEach((arg, i) => {
+    expect(args?.[i]).toEqual(arg)
+  })
+}
+
 test('deploy default application (no arguments)', async () => {
   await run({
     token: 'token',
@@ -92,7 +110,7 @@ test('deploy default application (no arguments)', async () => {
     cleverCLI: CLEVER_CLI
   })
   expect(execMock.mock.calls.some(call => call[1]?.[0] === 'login')).toBe(false)
-  expectCleverCLICallWithArgs(1, 'deploy')
+  expectDeploySpawnWithArgs('deploy')
   expect(setFailed).not.toHaveBeenCalled()
 })
 
@@ -103,7 +121,7 @@ test('deploy application with alias', async () => {
     alias: 'app-alias',
     cleverCLI: CLEVER_CLI
   })
-  expectCleverCLICallWithArgs(1, 'deploy', '--alias', 'app-alias')
+  expectDeploySpawnWithArgs('deploy', '--alias', 'app-alias')
   expect(setFailed).not.toHaveBeenCalled()
 })
 
@@ -121,8 +139,7 @@ test('deploy application with app ID', async () => {
     '--alias',
     'app_facade42-cafe-babe-cafe-deadf00dbaad'
   )
-  expectCleverCLICallWithArgs(
-    2,
+  expectDeploySpawnWithArgs(
     'deploy',
     '--alias',
     'app_facade42-cafe-babe-cafe-deadf00dbaad'
@@ -144,8 +161,7 @@ test('when both app ID and alias are provided, appID takes precedence', async ()
     '--alias',
     'app_facade42-cafe-babe-cafe-deadf00dbaad'
   )
-  expectCleverCLICallWithArgs(
-    2,
+  expectDeploySpawnWithArgs(
     'deploy',
     '--alias',
     'app_facade42-cafe-babe-cafe-deadf00dbaad'
@@ -164,7 +180,7 @@ test('passing extra env variables, using no input args', async () => {
   })
   expectCleverCLICallWithArgs(1, 'env', 'set', 'foo', 'bar')
   expectCleverCLICallWithArgs(2, 'env', 'set', 'egg', 'spam')
-  expectCleverCLICallWithArgs(3, 'deploy')
+  expectDeploySpawnWithArgs('deploy')
   expect(setSecret).toHaveBeenCalledWith('bar')
   expect(setSecret).toHaveBeenCalledWith('spam')
   expect(execMock.mock.calls[1]?.[2]).toMatchObject({ silent: true })
@@ -207,8 +223,7 @@ test('passing extra env variables, using appID', async () => {
     'egg',
     'spam'
   )
-  expectCleverCLICallWithArgs(
-    4,
+  expectDeploySpawnWithArgs(
     'deploy',
     '--alias',
     'app_facade42-cafe-babe-cafe-deadf00dbaad'
@@ -228,17 +243,58 @@ test('passing extra env variables, using alias only', async () => {
   })
   expectCleverCLICallWithArgs(1, 'env', 'set', '--alias', 'foo', 'foo', 'bar')
   expectCleverCLICallWithArgs(2, 'env', 'set', '--alias', 'foo', 'egg', 'spam')
-  expectCleverCLICallWithArgs(3, 'deploy', '--alias', 'foo')
+  expectDeploySpawnWithArgs('deploy', '--alias', 'foo')
 })
 
 test('deployment failure fails the workflow', async () => {
-  execMock.mockResolvedValue(42)
+  const child = makeFakeChild()
+  spawnMock.mockImplementation(() => {
+    setImmediate(() => {
+      child.stdout.end()
+      child.stderr.end()
+      child.emit('close', 42)
+    })
+    return child
+  })
   await run({
     token: 'token',
     secret: 'secret',
     cleverCLI: CLEVER_CLI
   })
   expect(setFailed).toHaveBeenCalledWith('Deployment failed with code 42')
+})
+
+test('deploy output pauses when the console applies backpressure', async () => {
+  const stdoutSpy = vi
+    .spyOn(process.stdout, 'write')
+    .mockImplementation(() => false)
+  const child = makeFakeChild()
+  spawnMock.mockReturnValue(child)
+  const finishedRun = run({
+    token: 'token',
+    secret: 'secret',
+    cleverCLI: CLEVER_CLI
+  })
+
+  try {
+    await new Promise(resolve => setImmediate(resolve))
+    const chunk = Buffer.alloc(64 * 1024, 'x')
+    chunk[chunk.length - 1] = 10
+    for (let i = 0; i < 64 && !child.stdout.isPaused(); i += 1) {
+      child.stdout.write(chunk)
+      await new Promise(resolve => setImmediate(resolve))
+    }
+
+    expect(child.stdout.isPaused()).toBe(true)
+  } finally {
+    stdoutSpy.mockImplementation(() => true)
+    process.stdout.emit('drain')
+    child.stdout.end()
+    child.stderr.end()
+    child.emit('close', 0)
+    await finishedRun
+    stdoutSpy.mockRestore()
+  }
 })
 
 test('timeout is interpreted in seconds, not milliseconds', async () => {
@@ -466,8 +522,7 @@ test('force deploy application', async () => {
     '--alias',
     'app_facade42-cafe-babe-cafe-deadf00dbaad'
   )
-  expectCleverCLICallWithArgs(
-    2,
+  expectDeploySpawnWithArgs(
     'deploy',
     '--alias',
     'app_facade42-cafe-babe-cafe-deadf00dbaad',
@@ -506,9 +561,7 @@ test('env-set failure fails the workflow with stderr, without leaking the value,
   const failureMessage = (setFailed as ReturnType<typeof vi.fn>).mock
     .calls[0]?.[0]
   expect(failureMessage).not.toContain('bar')
-  expect(execMock.mock.calls.some(call => call[1]?.[0] === 'deploy')).toBe(
-    false
-  )
+  expect(spawnMock).not.toHaveBeenCalled()
 })
 
 test('spawnDeploy pipes child stderr through the tee (annotations still reach stdout)', async () => {

--- a/src/action.test.ts
+++ b/src/action.test.ts
@@ -413,6 +413,25 @@ test('deploy fails before timeout: fails the workflow', async () => {
   expect(setFailed).toHaveBeenCalledWith('Deployment failed with code 42')
 })
 
+test('deploy terminated by a signal before timeout fails the workflow', async () => {
+  vi.useFakeTimers()
+  const child = makeFakeChild()
+  spawnMock.mockReturnValue(child)
+  const finished = run({
+    token: 'token',
+    secret: 'secret',
+    cleverCLI: CLEVER_CLI,
+    timeout: 1800
+  })
+  await vi.advanceTimersByTimeAsync(1000)
+  child.emit('close', null, 'SIGTERM')
+  await finished
+  expect(child.kill).not.toHaveBeenCalled()
+  expect(setFailed).toHaveBeenCalledWith(
+    'Deployment terminated by signal SIGTERM'
+  )
+})
+
 test('spawn error: fails the workflow and leaves no pending timer', async () => {
   vi.useFakeTimers()
   const child = makeFakeChild()

--- a/src/action.test.ts
+++ b/src/action.test.ts
@@ -119,13 +119,17 @@ test('deploys quietly when the log file cannot be opened', async () => {
   const openSpy = vi
     .spyOn(fs, 'open')
     .mockRejectedValue(new Error('ENOENT: missing directory'))
-  execMock.mockImplementation(async (_command, args, options) => {
-    if (args[0] === 'deploy') {
+  spawnMock.mockImplementation(() => {
+    const child = makeFakeChild()
+    setImmediate(() => {
       for (let index = 0; index < 256; index += 1) {
-        options?.outStream?.write(Buffer.alloc(1024))
+        child.stdout.write(Buffer.alloc(1024))
       }
-    }
-    return 0
+      child.stdout.end()
+      child.stderr.end()
+      child.emit('close', 0)
+    })
+    return child
   })
 
   try {
@@ -137,7 +141,7 @@ test('deploys quietly when the log file cannot be opened', async () => {
       quiet: true
     })
 
-    expectCleverCLICallWithArgs(1, 'deploy')
+    expectDeploySpawnWithArgs('deploy')
     expect(warning).toHaveBeenCalledWith(
       'deploy log output degraded: ENOENT: missing directory'
     )

--- a/src/action.ts
+++ b/src/action.ts
@@ -249,7 +249,13 @@ function spawnDeploy(
   }
   const exited = new Promise<number>((resolve, reject) => {
     child.once('error', reject)
-    child.once('close', code => resolve(code ?? 0))
+    child.once('close', (code, signal) => {
+      if (signal) {
+        reject(new Error(`Deployment terminated by signal ${signal}`))
+      } else {
+        resolve(code ?? 0)
+      }
+    })
   })
   return { child, exited }
 }

--- a/src/action.ts
+++ b/src/action.ts
@@ -200,7 +200,8 @@ export async function run({
         throw new Error(`Deployment failed with code ${result}`)
       }
     } else {
-      const code = await exec(cleverCLI, args, execOptions)
+      const { exited } = spawnDeploy(cleverCLI, args, execOptions)
+      const code = await exited
       core.info(`code: ${code}`)
       if (code !== 0) {
         throw new Error(`Deployment failed with code ${code}`)
@@ -226,12 +227,12 @@ export async function run({
 // --
 
 /**
- * Spawn the Clever CLI deploy ourselves so we keep a handle on the child
- * process and can terminate it when the deployment timeout fires.
+ * Spawn the Clever CLI deploy ourselves so child output is piped with native
+ * stream backpressure and timeout-mode deployments can terminate the process.
  *
  * Output is piped into the same tee stream used by @actions/exec (via
  * `options.outStream`) so console logging, log files and annotation injection
- * keep working identically to the non-timeout path.
+ * keep working identically for deploys and pre-deploy commands.
  */
 function spawnDeploy(
   cleverCLI: string,


### PR DESCRIPTION
## Summary

- Route every deploy through native child-process stream piping so slow output sinks pause stdout and stderr.
- Keep pre-deploy commands on `@actions/exec` and retain the shared console/log/annotation tee and deploy failure handling.

## Rationale

`@actions/exec` does not honor a false return from the deploy output stream, so non-timeout deployments can accumulate output without bound. Native stream piping propagates backpressure to the child process.

## Dependency

Stacked on #248 (`fix/signal-exit-status`) to reuse its corrected signal-exit semantics in the shared native deploy path. Merge or rebase #248 first.