### PR TITLE
chore: pass environment secrets into the reusable e2e suite

### DIFF
--- a/.github/workflows/e2e-manual.yml
+++ b/.github/workflows/e2e-manual.yml
@@ -78,6 +78,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+    secrets: inherit
     with:
       head_sha: ${{ needs.resolve.outputs.head_sha }}
       pr_number: ${{ needs.resolve.outputs.pr_number }}

--- a/.github/workflows/e2e-release-please.yml
+++ b/.github/workflows/e2e-release-please.yml
@@ -199,6 +199,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+    secrets: inherit
     with:
       head_sha: ${{ needs.resolve.outputs.head_sha }}
       pr_number: ${{ needs.resolve.outputs.pr_number }}

--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -797,7 +797,7 @@ jobs:
         run: node .candidate-source/src/e2e/scripts/write-suite-results.ts
 
       - name: Delete the captured app
-        if: always() && steps.candidate-state.outputs.proceed == 'true'
+        if: always() && steps.candidate-state.outputs.proceed == 'true' && steps.create.outcome == 'success'
         id: delete-app
         env:
           CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}

--- a/src/e2eWorkflowInvariants.test.ts
+++ b/src/e2eWorkflowInvariants.test.ts
@@ -185,13 +185,26 @@ describe('shared workflow policies', () => {
   )
 
   test.each(allWorkflows)(
-    '%s never inherits or forwards secrets to called workflows',
+    '%s inherits secrets only where the e2e environment needs them',
     (file, workflow) => {
-      for (const job of Object.values(workflow.jobs)) {
-        expect(job.secrets).toBeUndefined()
+      for (const [jobId, job] of Object.entries(workflow.jobs)) {
+        const isE2ESuiteCall =
+          job.uses === './.github/workflows/e2e-reusable.yml' &&
+          jobId === 'create-and-delete'
+        if (isE2ESuiteCall) {
+          expect(job.secrets).toBe('inherit')
+        } else {
+          expect(job.secrets).toBeUndefined()
+        }
       }
     }
   )
+
+  test('environment secrets can reach the called suite from both e2e callers', () => {
+    for (const workflow of [e2eManual, e2eAutomatic]) {
+      expect(jobOf(workflow, 'create-and-delete').secrets).toBe('inherit')
+    }
+  })
 
   test.each(allWorkflows)(
     '%s never persists checkout credentials',
@@ -724,6 +737,7 @@ describe('e2e-reusable', () => {
       return keys.includes('CLEVER_TOKEN') && keys.includes('E2E_HEALTH_VALUE')
     })
     expect(deleteApp.if).toContain('always()')
+    expect(deleteApp.if).toContain("steps.create.outcome == 'success'")
     expect(deleteApp.run).toBe(
       'node "$TRUSTED_WORKFLOW_DIR"/src/e2e/scripts/delete-app-and-prepare-evidence.ts'
     )


### PR DESCRIPTION
The first live qualification run failed at app creation: CLEVER_TOKEN and CLEVER_SECRET resolved empty inside the reusable suite, and clever-tools refused with "You're not logged in".

The design assumed that a called workflow job declaring the protected environment receives that environment's secrets. It does not. In a workflow_call job, the secrets context contains only what the caller passes or inherits; the job-level environment gates approval and overrides values for names already present, but injects nothing on its own (actions/runner#1490).

The two e2e caller jobs now use secrets: inherit, which is safe here because the calling context holds no Clever credentials at repository scope, so the only way for the environment secrets to materialize is through the environment the reusable job declares. The policy suite narrows its blanket inherit ban to exactly these two call sites.

The run also exposed a teardown gap: the delete step ran although no app had been created, then crashed on its own input guard. It now skips unless the create step succeeded, and the invariant pins that gate.

No application leaked; creation failed before any resource existed.

Part of acc-8cw7.
