### PR TITLE
chore: poll public health on the app domain instead of the git endpoint

### DIFF
--- a/src/e2e/clever-client.test.ts
+++ b/src/e2e/clever-client.test.ts
@@ -387,33 +387,55 @@ describe('createCleverController', () => {
     ).resolves.toBe('ABEiM0RVZneImaq7zN3u/w==')
   })
 
-  test('looks up the exact app ID and returns its deploy URL', async () => {
+  test('resolves the public origin from the first configured domain', async () => {
+    const calls: Array<{ args: string[]; timeoutMs: number }> = []
     const controller = createCleverController({
       cleverCLI: '/tmp/node_modules/.bin/clever',
-      runCommand: async () => ({
-        stdout: JSON.stringify([
-          {
-            id: 'orga_123',
-            applications: [
-              {
-                app_id: 'app_facade42-cafe-babe-cafe-deadf00dbaad',
-                name: 'actions-clever-cloud-e2e-123-4',
-                deploy_url: 'https://fixture.example.com'
-              }
-            ]
-          }
-        ]),
-        stderr: ''
-      })
+      runCommand: async (_cli, args, { timeoutMs }) => {
+        calls.push({ args, timeoutMs })
+        return {
+          stdout: JSON.stringify([
+            {
+              domainWithPathPrefix:
+                'app-facade42-cafe-babe-cafe-deadf00dbaad.cleverapps.io/'
+            },
+            { domainWithPathPrefix: 'example.com/' }
+          ]),
+          stderr: ''
+        }
+      }
     })
 
     await expect(
-      controller.getApplication('app_facade42-cafe-babe-cafe-deadf00dbaad')
-    ).resolves.toEqual({
-      appId: 'app_facade42-cafe-babe-cafe-deadf00dbaad',
-      name: 'actions-clever-cloud-e2e-123-4',
-      deployURL: 'https://fixture.example.com'
+      controller.getPublicOrigin('app_facade42-cafe-babe-cafe-deadf00dbaad')
+    ).resolves.toBe(
+      'https://app-facade42-cafe-babe-cafe-deadf00dbaad.cleverapps.io/'
+    )
+    expect(calls).toEqual([
+      {
+        args: [
+          'domain',
+          '--app',
+          'app_facade42-cafe-babe-cafe-deadf00dbaad',
+          '--format',
+          'json'
+        ],
+        timeoutMs: 30_000
+      }
+    ])
+  })
+
+  test('fails when the app exposes no public domain', async () => {
+    const controller = createCleverController({
+      cleverCLI: '/tmp/node_modules/.bin/clever',
+      runCommand: async () => ({ stdout: '[]', stderr: '' })
     })
+
+    await expect(
+      controller.getPublicOrigin('app_facade42-cafe-babe-cafe-deadf00dbaad')
+    ).rejects.toThrow(
+      'Application app_facade42-cafe-babe-cafe-deadf00dbaad has no public domain'
+    )
   })
 
   test('does not call cancel-deploy until the exact deployment becomes the latest WIP deployment', async () => {

--- a/src/e2e/clever-client.ts
+++ b/src/e2e/clever-client.ts
@@ -57,7 +57,7 @@ type CleverController = {
   ) => Promise<CreatedApplication>
   findApplicationByName: (name: string) => Promise<CreatedApplication>
   getEnvironmentValue: (appId: string, name: string) => Promise<string | null>
-  getApplication: (appId: string) => Promise<RetrievedApplication>
+  getPublicOrigin: (appId: string) => Promise<string>
   deleteApplication: (options: DeleteApplicationOptions) => Promise<void>
 }
 
@@ -66,10 +66,6 @@ type CreateApplicationController = {
     options: CreateApplicationOptions
   ) => Promise<CreatedApplication>
   findApplicationByName: (name: string) => Promise<CreatedApplication>
-}
-
-type RetrievedApplication = CreatedApplication & {
-  deployURL: string
 }
 
 type DeploymentActivity = {
@@ -463,20 +459,20 @@ export function createCleverController({
       return typeof match?.value === 'string' ? match.value : null
     },
 
-    async getApplication(appId: string): Promise<RetrievedApplication> {
-      const match = (await listApplications())
-        .flatMap(organisation => organisation.applications ?? [])
-        .find(application => application.app_id === appId)
-
-      if (!match || !match.name || !match.deploy_url) {
-        throw new Error(`Application ${appId} is missing its name or deploy URL`)
+    async getPublicOrigin(appId: string): Promise<string> {
+      const result = await runCommand(
+        cleverCLI,
+        ['domain', '--app', appId, '--format', 'json'],
+        { timeoutMs: COMMAND_TIMEOUT_MS }
+      )
+      const domains = JSON.parse(result.stdout) as Array<{
+        domainWithPathPrefix?: string
+      }>
+      const domain = domains[0]?.domainWithPathPrefix
+      if (!domain) {
+        throw new Error(`Application ${appId} has no public domain`)
       }
-
-      return {
-        appId,
-        name: match.name,
-        deployURL: match.deploy_url
-      }
+      return `https://${domain.endsWith('/') ? domain : `${domain}/`}`
     },
 
     async deleteApplication({

--- a/src/e2e/scripts/assert-build-failure.ts
+++ b/src/e2e/scripts/assert-build-failure.ts
@@ -47,8 +47,10 @@ const failedDeployment = await waitForNewFailedDeploymentActivity({
   listActivity: controller.listActivity
 })
 
-const application = await controller.getApplication(appId)
-const healthURL = new URL('/health', `${application.deployURL}/`).toString()
+const healthURL = new URL(
+  '/health',
+  await controller.getPublicOrigin(appId)
+).toString()
 const health = await waitForHealthyDeployment({
   appId,
   healthURL,

--- a/src/e2e/scripts/assert-divergent-rejection.ts
+++ b/src/e2e/scripts/assert-divergent-rejection.ts
@@ -28,8 +28,10 @@ const controller = createCleverController({
   runCommand: createRunCommand()
 })
 
-const application = await controller.getApplication(appId)
-const healthURL = new URL('/health', `${application.deployURL}/`).toString()
+const healthURL = new URL(
+  '/health',
+  await controller.getPublicOrigin(appId)
+).toString()
 const health = await confirmRejectedDeploymentPreservesLiveApp({
   appId,
   healthURL,

--- a/src/e2e/scripts/assert-startup-failure.ts
+++ b/src/e2e/scripts/assert-startup-failure.ts
@@ -47,8 +47,10 @@ const failedDeployment = await waitForNewFailedDeploymentActivity({
   listActivity: controller.listActivity
 })
 
-const application = await controller.getApplication(appId)
-const healthURL = new URL('/health', `${application.deployURL}/`).toString()
+const healthURL = new URL(
+  '/health',
+  await controller.getPublicOrigin(appId)
+).toString()
 const health = await waitForHealthyDeployment({
   appId,
   healthURL,

--- a/src/e2e/scripts/observe-divergent-force.ts
+++ b/src/e2e/scripts/observe-divergent-force.ts
@@ -34,8 +34,10 @@ const controller = createCleverController({
   runCommand: createRunCommand()
 })
 
-const application = await controller.getApplication(appId)
-const healthURL = new URL('/health', `${application.deployURL}/`).toString()
+const healthURL = new URL(
+  '/health',
+  await controller.getPublicOrigin(appId)
+).toString()
 const result = await waitForNewHealthyDeployment({
   appId,
   healthURL,

--- a/src/e2e/scripts/observe-env-deployment.ts
+++ b/src/e2e/scripts/observe-env-deployment.ts
@@ -22,8 +22,10 @@ const controller = createCleverController({
   runCommand: createRunCommand()
 })
 
-const application = await controller.getApplication(appId)
-const healthURL = new URL('/health', `${application.deployURL}/`).toString()
+const healthURL = new URL(
+  '/health',
+  await controller.getPublicOrigin(appId)
+).toString()
 const health = await waitForHealthyDeployment({
   appId,
   healthURL,

--- a/src/e2e/scripts/observe-healthy-deployment.ts
+++ b/src/e2e/scripts/observe-healthy-deployment.ts
@@ -21,8 +21,10 @@ const controller = createCleverController({
   runCommand: createRunCommand()
 })
 
-const application = await controller.getApplication(appId)
-const healthURL = new URL('/health', `${application.deployURL}/`).toString()
+const healthURL = new URL(
+  '/health',
+  await controller.getPublicOrigin(appId)
+).toString()
 const health = await waitForHealthyDeployment({
   appId,
   healthURL,

--- a/src/e2e/scripts/observe-recovery-deployment.ts
+++ b/src/e2e/scripts/observe-recovery-deployment.ts
@@ -21,8 +21,10 @@ const controller = createCleverController({
   runCommand: createRunCommand()
 })
 
-const application = await controller.getApplication(appId)
-const healthURL = new URL('/health', `${application.deployURL}/`).toString()
+const healthURL = new URL(
+  '/health',
+  await controller.getPublicOrigin(appId)
+).toString()
 const health = await waitForHealthyDeployment({
   appId,
   healthURL,

--- a/src/e2e/scripts/observe-same-commit-ignore.ts
+++ b/src/e2e/scripts/observe-same-commit-ignore.ts
@@ -38,8 +38,10 @@ await confirmNoNewDeploymentActivity({
   pollIntervalMs: 5_000
 })
 
-const application = await controller.getApplication(appId)
-const healthURL = new URL('/health', `${application.deployURL}/`).toString()
+const healthURL = new URL(
+  '/health',
+  await controller.getPublicOrigin(appId)
+).toString()
 const health = await waitForHealthyDeployment({
   appId,
   healthURL,

--- a/src/e2e/scripts/observe-same-commit-rebuild.ts
+++ b/src/e2e/scripts/observe-same-commit-rebuild.ts
@@ -39,8 +39,10 @@ const deployment = await waitForNewSuccessfulDeploymentActivity({
   listActivity: controller.listActivity
 })
 
-const application = await controller.getApplication(appId)
-const healthURL = new URL('/health', `${application.deployURL}/`).toString()
+const healthURL = new URL(
+  '/health',
+  await controller.getPublicOrigin(appId)
+).toString()
 const health = await waitForHealthyDeployment({
   appId,
   healthURL,

--- a/src/e2e/scripts/observe-same-commit-restart.ts
+++ b/src/e2e/scripts/observe-same-commit-restart.ts
@@ -39,8 +39,10 @@ const deployment = await waitForNewSuccessfulDeploymentActivity({
   listActivity: controller.listActivity
 })
 
-const application = await controller.getApplication(appId)
-const healthURL = new URL('/health', `${application.deployURL}/`).toString()
+const healthURL = new URL(
+  '/health',
+  await controller.getPublicOrigin(appId)
+).toString()
 const health = await waitForHealthyDeployment({
   appId,
   healthURL,

--- a/src/e2e/scripts/observe-timeout-cancellation.ts
+++ b/src/e2e/scripts/observe-timeout-cancellation.ts
@@ -31,8 +31,10 @@ const controller = createCleverController({
   runCommand: createRunCommand()
 })
 
-const application = await controller.getApplication(appId)
-const healthURL = new URL('/health', `${application.deployURL}/`).toString()
+const healthURL = new URL(
+  '/health',
+  await controller.getPublicOrigin(appId)
+).toString()
 const result = await cancelTimedOutDeploymentPreservesLiveApp({
   appId,
   healthURL,


### PR DESCRIPTION
The second live qualification run deployed its first fixture successfully, then hung polling for public health. The app was healthy the whole time: probing its real domain returned the expected fixture JSON.

The suite was polling the wrong host. Clever's deploy_url field is the git push endpoint, and every observe script derived its health URL from it. The stubbed tests modeled deployURL as an HTTP origin, so only a live run could expose the mismatch.

The controller now resolves the public origin from the app's first configured domain (clever domain --format json), and all eleven observe and assert scripts build their health URL from that. The git-endpoint lookup and its type are gone.

The hung step self-terminated at its ten-minute deadline and teardown deleted the app, which also gave the failure path its first live exercise.

Part of acc-8cw7.
