### PR TITLE
chore: run clever control commands outside the workspace

### DIFF
--- a/src/e2e/workflow-adapters.test.ts
+++ b/src/e2e/workflow-adapters.test.ts
@@ -12,6 +12,7 @@ afterEach(() => {
 
 describe('createRunCommand', () => {
   test('runs the CLI with utf8 output, ambient env, timeout and a 10MB buffer', async () => {
+    vi.stubEnv('RUNNER_TEMP', '/runner/temp')
     const calls: Array<{
       cli: string
       args: string[]
@@ -38,11 +39,27 @@ describe('createRunCommand', () => {
         options: {
           encoding: 'utf8',
           env: process.env,
+          cwd: '/runner/temp',
           timeout: 1234,
           maxBuffer: 1024 * 1024 * 10
         }
       }
     ])
+  })
+
+  test('falls back to the working directory outside the runner', async () => {
+    vi.stubEnv('RUNNER_TEMP', '')
+    let observedCwd: unknown
+
+    const runCommand = createRunCommand({
+      execFileAsync: async (_cli, _args, options) => {
+        observedCwd = (options as { cwd?: string }).cwd
+        return { stdout: '', stderr: '' }
+      }
+    })
+
+    await runCommand('clever', [], { timeoutMs: 1 })
+    expect(observedCwd).toBe(process.cwd())
   })
 
   test('rethrows failures with trimmed stderr, exit details and the cause', async () => {

--- a/src/e2e/workflow-adapters.ts
+++ b/src/e2e/workflow-adapters.ts
@@ -22,6 +22,7 @@ type ExecFileAsync = (
   options: {
     encoding: 'utf8'
     env: NodeJS.ProcessEnv
+    cwd: string
     timeout: number
     maxBuffer: number
   }
@@ -43,9 +44,13 @@ export function createRunCommand({
 }: CreateRunCommandOptions = {}): RunCommand {
   return async (cli, args, { timeoutMs }) => {
     try {
+      // The candidate action container writes a root-owned .clever.json into
+      // the workspace; running control commands from there makes clever-tools
+      // fail with EACCES even after a successful remote operation.
       const { stdout, stderr } = await execFileAsync(cli, args, {
         encoding: 'utf8',
         env: process.env,
+        cwd: process.env.RUNNER_TEMP || process.cwd(),
         timeout: timeoutMs,
         maxBuffer: 1024 * 1024 * 10
       })


### PR DESCRIPTION
The second live run's teardown deleted the app on Clever Cloud, then still failed: clever-tools exited with EACCES on the workspace .clever.json after the successful remote delete.

The candidate action runs in a container as root and recreates that link file in the workspace during scenario deploys. Host-side control commands then trip over the root-owned file even though none of them need workspace state; they operate purely on app IDs and environment credentials.

Control commands now run from RUNNER_TEMP (working directory as fallback outside Actions), so the app-under-test can do whatever it wants to the workspace without affecting the control plane. This also keeps the provisioning link out of the fixture workspace from the start.

Verified from the failed run while fixing this: the failure evidence artifact contains only the fixture commit, candidate SHA, and image digest, and the app was confirmed deleted.

Part of acc-8cw7.
