### PR TITLE
chore: e2e baseline qualification candidate

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,10 +13,11 @@
     "node",
     "deploy",
     "deployment",
-    "clever-cloud"
+    "clever-cloud",
+    "e2e"
   ],
   "author": {
-    "name": "François Best",
+    "name": "Fran\u00e7ois Best",
     "email": "contact@francoisbest.com",
     "url": "https://francoisbest.com"
   },


### PR DESCRIPTION
Baseline candidate for live e2e qualification. The only change is a package.json keyword, enough to trigger the preview image build.

Testing the suite against known-good runtime code separates suite faults from refactor faults before PR 256 goes through the same gauntlet. This branch gets a merge commit from master after every suite fix so its candidate image always carries the current e2e code.

**Not meant to be merged**.

Part of acc-8cw7.
