### PR TITLE
chore: reduce e2e observer timeout to five minutes

### DIFF
--- a/src/e2e/deployment-observer.ts
+++ b/src/e2e/deployment-observer.ts
@@ -28,7 +28,7 @@ type NewDeploymentActivityOptions = {
   pollIntervalMs?: number
 }
 
-const DEFAULT_SETTLE_TIMEOUT_MS = 10 * 60_000
+const DEFAULT_SETTLE_TIMEOUT_MS = 5 * 60_000
 const DEFAULT_NO_NEW_ACTIVITY_TIMEOUT_MS = 15_000
 const DEFAULT_POLL_INTERVAL_MS = 5_000
 const DEFAULT_HEALTH_CHECK_TIMEOUT_MS = 10_000


### PR DESCRIPTION
Live runs observe healthy deployments within a minute; a ten-minute settle wait only delays failing runs. Part of acc-8cw7.