### PR TITLE
chore: match the real non-fast-forward rejection wording

### DIFF
--- a/src/e2e/scripts/assert-divergent-rejection.ts
+++ b/src/e2e/scripts/assert-divergent-rejection.ts
@@ -64,6 +64,7 @@ if (health.CC_COMMIT_ID !== previousState.commitId) {
 
 const logContent = await readFile(logPath, 'utf8')
 const nonFastForwardMarkers = [
+  'not a simple fast-forward',
   'non-fast-forward',
   '[rejected]',
   'fetch first',


### PR DESCRIPTION
The baseline run reached the divergent scenario and the non-fast-forward rejection behaved exactly as designed: the deploy failed, production stayed on the prior commit, and no replacement activity appeared.

The assertion still failed because it greps the log for git porcelain phrases, while clever-tools actually prints "Push rejected because it was not a simple fast-forward". That wording joins the marker list.

Seven of nine scenario groups passed live before this: healthy deploy, env and quiet log checks, all four same-commit policies, build failure, startup failure, and recovery. Teardown and evidence were clean.

Part of acc-8cw7.
