### PR TITLE
chore: resolve cancelled deployments that settle in any state

### DIFF
--- a/src/e2e/clever-client.test.ts
+++ b/src/e2e/clever-client.test.ts
@@ -655,7 +655,98 @@ describe('createCleverController', () => {
     }
   })
 
-  test('fails with a useful deadline error when a timed-out deployment never reaches CANCELLED', async () => {
+  test('resolves with the settled state when the deployment completes despite the cancel request', async () => {
+    let activityCalls = 0
+    let now = 0
+    const dateNowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now)
+
+    try {
+      const controller = createCleverController({
+        cleverCLI: '/tmp/node_modules/.bin/clever',
+        runCommand: async (_cli, args) => {
+          if (args[0] === 'cancel-deploy') {
+            return { stdout: '', stderr: '' }
+          }
+
+          activityCalls += 1
+          return {
+            stdout: JSON.stringify([
+              {
+                uuid: 'deployment-timeout',
+                action: 'DEPLOY',
+                state: activityCalls === 1 ? 'WIP' : 'OK',
+                commit: 'commit-timeout'
+              }
+            ]),
+            stderr: ''
+          }
+        },
+        sleep: async timeoutMs => {
+          now += timeoutMs
+        },
+        settleTimeoutMs: 20,
+        pollIntervalMs: 1
+      })
+
+      await expect(
+        controller.cancelDeployment({
+          appId: 'app_facade42-cafe-babe-cafe-deadf00dbaad',
+          deploymentId: 'deployment-timeout'
+        })
+      ).resolves.toEqual({
+        uuid: 'deployment-timeout',
+        action: 'DEPLOY',
+        state: 'OK',
+        commit: 'commit-timeout'
+      })
+    } finally {
+      dateNowSpy.mockRestore()
+    }
+  })
+
+  test('resolves with the settled state without cancelling when the deployment settles first', async () => {
+    let cancelCalls = 0
+
+    const controller = createCleverController({
+      cleverCLI: '/tmp/node_modules/.bin/clever',
+      runCommand: async (_cli, args) => {
+        if (args[0] === 'cancel-deploy') {
+          cancelCalls += 1
+          return { stdout: '', stderr: '' }
+        }
+
+        return {
+          stdout: JSON.stringify([
+            {
+              uuid: 'deployment-timeout',
+              action: 'DEPLOY',
+              state: 'OK',
+              commit: 'commit-timeout'
+            }
+          ]),
+          stderr: ''
+        }
+      },
+      sleep: async () => {},
+      settleTimeoutMs: 20,
+      pollIntervalMs: 1
+    })
+
+    await expect(
+      controller.cancelDeployment({
+        appId: 'app_facade42-cafe-babe-cafe-deadf00dbaad',
+        deploymentId: 'deployment-timeout'
+      })
+    ).resolves.toEqual({
+      uuid: 'deployment-timeout',
+      action: 'DEPLOY',
+      state: 'OK',
+      commit: 'commit-timeout'
+    })
+    expect(cancelCalls).toBe(0)
+  })
+
+  test('fails with a useful deadline error when a timed-out deployment never settles', async () => {
     let activityCalls = 0
     let now = 0
     const dateNowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now)
@@ -694,7 +785,7 @@ describe('createCleverController', () => {
           deploymentId: 'deployment-timeout'
         })
       ).rejects.toThrow(
-        'Timed out while waiting for deployment deployment-timeout on app_facade42-cafe-babe-cafe-deadf00dbaad to reach CANCELLED. Last state: QUEUED'
+        'Timed out while waiting for deployment deployment-timeout on app_facade42-cafe-babe-cafe-deadf00dbaad to settle. Last state: QUEUED'
       )
     } finally {
       dateNowSpy.mockRestore()
@@ -737,7 +828,7 @@ describe('createCleverController', () => {
     )
   })
 
-  test('fails when the latest deployment never reaches CANCELLED during teardown', async () => {
+  test('fails when the latest deployment never settles during teardown', async () => {
     let now = 0
     const dateNowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now)
 
@@ -769,7 +860,7 @@ describe('createCleverController', () => {
           name: 'actions-clever-cloud-e2e-123-4'
         })
       ).rejects.toThrow(
-        'Failed to delete actions-clever-cloud-e2e-123-4 (app_facade42-cafe-babe-cafe-deadf00dbaad): Timed out while waiting for deployment dep_123 on app_facade42-cafe-babe-cafe-deadf00dbaad to reach CANCELLED. Last state: WIP'
+        'Failed to delete actions-clever-cloud-e2e-123-4 (app_facade42-cafe-babe-cafe-deadf00dbaad): Timed out while waiting for deployment dep_123 on app_facade42-cafe-babe-cafe-deadf00dbaad to settle. Last state: WIP'
       )
     } finally {
       dateNowSpy.mockRestore()

--- a/src/e2e/clever-client.ts
+++ b/src/e2e/clever-client.ts
@@ -187,15 +187,13 @@ export function createCleverController({
     )
   }
 
-  async function waitForDeploymentState({
+  async function waitForSettledDeploymentState({
     appId,
     deploymentId,
-    expectedState,
     timeoutMs = settleTimeoutMs
   }: {
     appId: string
     deploymentId: string
-    expectedState: string
     timeoutMs?: number
   }): Promise<DeploymentActivity> {
     const deadline = Date.now() + timeoutMs
@@ -213,14 +211,14 @@ export function createCleverController({
         lastObservedState = deployment.state
       }
 
-      if (Date.now() >= deadline) {
-        throw new Error(
-          `Timed out while waiting for deployment ${deploymentId} on ${appId} to reach ${expectedState}. Last state: ${lastObservedState}`
-        )
+      if (isSettled(deployment)) {
+        return deployment
       }
 
-      if (deployment?.state === expectedState) {
-        return deployment
+      if (Date.now() >= deadline) {
+        throw new Error(
+          `Timed out while waiting for deployment ${deploymentId} on ${appId} to settle. Last state: ${lastObservedState}`
+        )
       }
 
       await sleepUntilNextPoll({
@@ -234,14 +232,12 @@ export function createCleverController({
   async function waitForLatestCancellableDeployment({
     appId,
     deploymentId,
-    timeoutMs = settleTimeoutMs,
-    returnSettled = false
+    timeoutMs = settleTimeoutMs
   }: {
     appId: string
     deploymentId: string
     timeoutMs?: number
-    returnSettled?: boolean
-  }): Promise<(DeploymentActivity & { uuid: string }) | null> {
+  }): Promise<DeploymentActivity & { uuid: string }> {
     const deadline = Date.now() + timeoutMs
     let lastObservedState = '(missing)'
 
@@ -264,18 +260,8 @@ export function createCleverController({
         lastObservedState = matchingDeployment.state
       }
 
-      if (
-        matchingDeployment?.uuid === deploymentId &&
-        matchingDeployment.state &&
-        !IN_PROGRESS_STATES.has(matchingDeployment.state)
-      ) {
-        if (returnSettled) {
-          return null
-        }
-
-        throw new Error(
-          `Deployment ${deploymentId} on ${appId} reached ${matchingDeployment.state} before it could be cancelled`
-        )
+      if (matchingDeployment?.uuid && isSettled(matchingDeployment)) {
+        return matchingDeployment as DeploymentActivity & { uuid: string }
       }
 
       if (Date.now() >= deadline) {
@@ -331,26 +317,23 @@ export function createCleverController({
   }): Promise<DeploymentActivity> {
     const deadline = Date.now() + timeoutMs
 
-    const cancellableDeployment = await waitForLatestCancellableDeployment({
+    const deployment = await waitForLatestCancellableDeployment({
       appId,
       deploymentId,
       timeoutMs: remainingBeforeDeadline(deadline)
     })
 
-    if (!cancellableDeployment) {
-      throw new Error(
-        `Deployment ${deploymentId} on ${appId} settled before it could be cancelled`
-      )
+    if (isSettled(deployment)) {
+      return deployment
     }
 
     await runCommand(cleverCLI, ['cancel-deploy', '--app', appId], {
       timeoutMs: Math.min(COMMAND_TIMEOUT_MS, Math.max(1, remainingBeforeDeadline(deadline)))
     })
 
-    return waitForDeploymentState({
+    return waitForSettledDeploymentState({
       appId,
       deploymentId,
-      expectedState: 'CANCELLED',
       timeoutMs: remainingBeforeDeadline(deadline)
     })
   }
@@ -501,11 +484,10 @@ export function createCleverController({
           const cancellableDeployment = await waitForLatestCancellableDeployment({
             appId,
             deploymentId: latestActiveDeployment.uuid,
-            timeoutMs: remainingBeforeDeadline(deadline),
-            returnSettled: true
+            timeoutMs: remainingBeforeDeadline(deadline)
           })
 
-          if (!cancellableDeployment) {
+          if (isSettled(cancellableDeployment)) {
             continue
           }
 
@@ -516,10 +498,9 @@ export function createCleverController({
             )
           })
 
-          await waitForDeploymentState({
+          await waitForSettledDeploymentState({
             appId,
             deploymentId: cancellableDeployment.uuid,
-            expectedState: 'CANCELLED',
             timeoutMs: remainingBeforeDeadline(deadline)
           })
         }
@@ -535,6 +516,12 @@ export function createCleverController({
       }
     }
   }
+}
+
+function isSettled(
+  deployment: DeploymentActivity | undefined
+): deployment is DeploymentActivity & { state: string } {
+  return Boolean(deployment?.state && !IN_PROGRESS_STATES.has(deployment.state))
 }
 
 function remainingBeforeDeadline(deadlineAt: number): number {

--- a/src/e2e/deployment-observer.test.ts
+++ b/src/e2e/deployment-observer.test.ts
@@ -1002,6 +1002,7 @@ test('accepts a timed-out deployment that completed before cancellation', async 
 
 test('classifies the settled state when cancellation loses the race', async () => {
   let activityCalls = 0
+  const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
   await expect(
     cancelTimedOutDeploymentPreservesLiveApp({
@@ -1046,6 +1047,11 @@ test('classifies the settled state when cancellation loses the race', async () =
     outcome: 'completed',
     deployment: { uuid: 'deployment-timeout', state: 'OK' }
   })
+
+  expect(warnSpy).toHaveBeenCalledWith(
+    'Cancellation did not settle the deployment: Deployment deployment-timeout reached OK before it could be cancelled'
+  )
+  warnSpy.mockRestore()
 })
 
 test('verifies the prior app stays live when the timed-out deployment settles failed', async () => {

--- a/src/e2e/deployment-observer.ts
+++ b/src/e2e/deployment-observer.ts
@@ -189,7 +189,12 @@ export async function cancelTimedOutDeploymentPreservesLiveApp({
         found.uuid,
         remainingBeforeDeadline(deadlineAt)
       )
-    } catch {
+    } catch (error) {
+      console.warn(
+        `Cancellation did not settle the deployment: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      )
       deployment = await waitForSettledDeployment({
         appId,
         deploymentId: found.uuid,


### PR DESCRIPTION
Run six of the live suite failed again on the timeout-cancellation step, with the whole 5-minute observer budget spent inside `cancelDeployment`.

The evidence shows why. After `clever cancel-deploy` is issued, the client waited for the deployment to reach the exact state CANCELLED. In run six the cancel request landed while the remote build sat in the 180s `CC_POST_BUILD_HOOK`, the deployment went on to settle in another state, and the CANCELLED wait polled to the deadline. The bare catch in the observer then swallowed that error, so the settled-state fallback started with zero budget and failed with the misleading "to settle" message. Teardown ran 2 seconds later and found no active deployment, proving the deployment had settled well before the deadline.

This makes the client side of cancellation state-agnostic, matching what #265 did for the observer:

- after issuing cancel-deploy, wait for any settled state and return it; the caller already classifies completed, cancelled and failed outcomes
- when the deployment settles before it can be cancelled, return the settled entry instead of throwing
- apply the same settle wait to the teardown cancel loop, which had the same latent stall
- log the swallowed cancellation error so the next run tells us what actually happened

Part of the qualification of the live e2e suite (acc-8cw7).
