### PR TITLE
chore: classify vanished deployment rows behind CANCEL activity as cancelled

### DIFF
--- a/src/e2e/clever-client.test.ts
+++ b/src/e2e/clever-client.test.ts
@@ -704,6 +704,129 @@ describe('createCleverController', () => {
     }
   })
 
+  test('classifies a deployment row that vanishes behind a settled CANCEL activity as cancelled', async () => {
+    let activityCalls = 0
+    let now = 0
+    const dateNowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now)
+
+    try {
+      const controller = createCleverController({
+        cleverCLI: '/tmp/node_modules/.bin/clever',
+        runCommand: async (_cli, args) => {
+          if (args[0] === 'cancel-deploy') {
+            return { stdout: '', stderr: '' }
+          }
+
+          activityCalls += 1
+          return {
+            stdout: JSON.stringify(
+              activityCalls === 1
+                ? [
+                    {
+                      uuid: 'deployment-timeout',
+                      action: 'DEPLOY',
+                      state: 'WIP',
+                      commit: 'commit-timeout'
+                    }
+                  ]
+                : [
+                    {
+                      uuid: 'activity-cancel',
+                      action: 'CANCEL',
+                      state: 'OK',
+                      commit: null
+                    },
+                    {
+                      uuid: 'deployment-forced',
+                      action: 'DEPLOY',
+                      state: 'OK',
+                      commit: 'commit-forced'
+                    }
+                  ]
+            ),
+            stderr: ''
+          }
+        },
+        sleep: async timeoutMs => {
+          now += timeoutMs
+        },
+        settleTimeoutMs: 20,
+        pollIntervalMs: 1
+      })
+
+      await expect(
+        controller.cancelDeployment({
+          appId: 'app_facade42-cafe-babe-cafe-deadf00dbaad',
+          deploymentId: 'deployment-timeout'
+        })
+      ).resolves.toEqual({
+        uuid: 'deployment-timeout',
+        action: 'DEPLOY',
+        state: 'CANCELLED',
+        commit: 'commit-timeout'
+      })
+    } finally {
+      dateNowSpy.mockRestore()
+    }
+  })
+
+  test('keeps polling when the deployment row is missing without a settled CANCEL activity', async () => {
+    let now = 0
+    const dateNowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now)
+    let sawCancel = false
+
+    try {
+      const controller = createCleverController({
+        cleverCLI: '/tmp/node_modules/.bin/clever',
+        runCommand: async (_cli, args) => {
+          if (args[0] === 'cancel-deploy') {
+            sawCancel = true
+            return { stdout: '', stderr: '' }
+          }
+
+          return {
+            stdout: JSON.stringify(
+              sawCancel
+                ? [
+                    {
+                      uuid: 'deployment-forced',
+                      action: 'DEPLOY',
+                      state: 'OK',
+                      commit: 'commit-forced'
+                    }
+                  ]
+                : [
+                    {
+                      uuid: 'deployment-timeout',
+                      action: 'DEPLOY',
+                      state: 'WIP',
+                      commit: 'commit-timeout'
+                    }
+                  ]
+            ),
+            stderr: ''
+          }
+        },
+        sleep: async timeoutMs => {
+          now += timeoutMs
+        },
+        settleTimeoutMs: 20,
+        pollIntervalMs: 1
+      })
+
+      await expect(
+        controller.cancelDeployment({
+          appId: 'app_facade42-cafe-babe-cafe-deadf00dbaad',
+          deploymentId: 'deployment-timeout'
+        })
+      ).rejects.toThrow(
+        'Timed out while waiting for deployment deployment-timeout on app_facade42-cafe-babe-cafe-deadf00dbaad to settle. Last state: (missing)'
+      )
+    } finally {
+      dateNowSpy.mockRestore()
+    }
+  })
+
   test('resolves with the settled state without cancelling when the deployment settles first', async () => {
     let cancelCalls = 0
 
@@ -1011,6 +1134,65 @@ describe('createCleverController', () => {
       expect(call.cli).toBe('/tmp/node_modules/.bin/clever')
       expect(call.timeoutMs).toBeGreaterThan(0)
     }
+  })
+
+  test('teardown finishes when a cancelled deployment row vanishes behind a CANCEL activity', async () => {
+    const calls: Array<{
+      cli: string
+      args: string[]
+      timeoutMs: number
+    }> = []
+    let sawCancel = false
+
+    const controller = createCleverController({
+      cleverCLI: '/tmp/node_modules/.bin/clever',
+      runCommand: async (cli, args, { timeoutMs }) => {
+        calls.push({ cli, args, timeoutMs })
+
+        if (args[0] === 'activity') {
+          return {
+            stdout: JSON.stringify(
+              sawCancel
+                ? [{ uuid: 'activity-cancel', action: 'CANCEL', state: 'OK', commit: null }]
+                : [{ uuid: 'dep_123', action: 'DEPLOY', state: 'WIP' }]
+            ),
+            stderr: ''
+          }
+        }
+
+        if (args[0] === 'cancel-deploy') {
+          sawCancel = true
+          return { stdout: '', stderr: '' }
+        }
+
+        if (args[0] === 'delete') {
+          return { stdout: '', stderr: '' }
+        }
+
+        return {
+          stdout: JSON.stringify([{ id: 'orga_123', applications: [] }]),
+          stderr: ''
+        }
+      },
+      sleep: async () => {}
+    })
+
+    await expect(
+      controller.deleteApplication({
+        appId: 'app_facade42-cafe-babe-cafe-deadf00dbaad',
+        name: 'actions-clever-cloud-e2e-123-4'
+      })
+    ).resolves.toBeUndefined()
+
+    expect(calls.map(call => call.args[0])).toEqual([
+      'activity',
+      'activity',
+      'cancel-deploy',
+      'activity',
+      'activity',
+      'delete',
+      'applications'
+    ])
   })
 
   test('teardown cancels each active deployment before deleting the captured app ID', async () => {

--- a/src/e2e/clever-client.ts
+++ b/src/e2e/clever-client.ts
@@ -195,17 +195,16 @@ export function createCleverController({
     appId: string
     deploymentId: string
     timeoutMs?: number
-  }): Promise<DeploymentActivity> {
+  }): Promise<DeploymentActivity | null> {
     const deadline = Date.now() + timeoutMs
     let lastObservedState = '(missing)'
 
     for (;;) {
-      const deployment = (
-        await listActivity(
-          appId,
-          Math.min(COMMAND_TIMEOUT_MS, Math.max(1, remainingBeforeDeadline(deadline)))
-        )
-      ).find(activity => activity.uuid === deploymentId)
+      const activity = await listActivity(
+        appId,
+        Math.min(COMMAND_TIMEOUT_MS, Math.max(1, remainingBeforeDeadline(deadline)))
+      )
+      const deployment = activity.find(entry => entry.uuid === deploymentId)
 
       if (deployment?.state) {
         lastObservedState = deployment.state
@@ -213,6 +212,12 @@ export function createCleverController({
 
       if (isSettled(deployment)) {
         return deployment
+      }
+
+      // Clever removes the DEPLOY row of a cancelled deployment and replaces
+      // it with a CANCEL activity entry under a new uuid.
+      if (!deployment && hasSettledCancelActivity(activity)) {
+        return null
       }
 
       if (Date.now() >= deadline) {
@@ -331,11 +336,13 @@ export function createCleverController({
       timeoutMs: Math.min(COMMAND_TIMEOUT_MS, Math.max(1, remainingBeforeDeadline(deadline)))
     })
 
-    return waitForSettledDeploymentState({
+    const settled = await waitForSettledDeploymentState({
       appId,
       deploymentId,
       timeoutMs: remainingBeforeDeadline(deadline)
     })
+
+    return settled ?? { ...deployment, state: 'CANCELLED' }
   }
 
   return {
@@ -522,6 +529,10 @@ function isSettled(
   deployment: DeploymentActivity | undefined
 ): deployment is DeploymentActivity & { state: string } {
   return Boolean(deployment?.state && !IN_PROGRESS_STATES.has(deployment.state))
+}
+
+function hasSettledCancelActivity(activity: DeploymentActivity[]): boolean {
+  return activity.some(entry => entry.action === 'CANCEL' && isSettled(entry))
 }
 
 function remainingBeforeDeadline(deadlineAt: number): number {

--- a/src/e2e/deployment-observer.test.ts
+++ b/src/e2e/deployment-observer.test.ts
@@ -1054,6 +1054,76 @@ test('classifies the settled state when cancellation loses the race', async () =
   warnSpy.mockRestore()
 })
 
+test('classifies a deployment row that vanishes behind a settled CANCEL activity as cancelled', async () => {
+  let activityCalls = 0
+  const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+  await expect(
+    cancelTimedOutDeploymentPreservesLiveApp({
+      appId: 'app_facade42-cafe-babe-cafe-deadf00dbaad',
+      healthURL: 'https://fixture.example.com/health',
+      expectedCancelledCommitID: 'commit-timeout',
+      expectedScenario: 'healthy',
+      previousCommitID: 'commit-forced',
+      previousDeploymentID: 'deployment-forced',
+      listActivity: async () => {
+        activityCalls += 1
+        return activityCalls === 1
+          ? [
+              {
+                action: 'DEPLOY',
+                state: 'WIP',
+                uuid: 'deployment-timeout',
+                commit: 'commit-timeout'
+              },
+              {
+                action: 'DEPLOY',
+                state: 'SUCCESS',
+                uuid: 'deployment-forced',
+                commit: 'commit-forced'
+              }
+            ]
+          : [
+              {
+                action: 'CANCEL',
+                state: 'OK',
+                uuid: 'activity-cancel'
+              },
+              {
+                action: 'DEPLOY',
+                state: 'SUCCESS',
+                uuid: 'deployment-forced',
+                commit: 'commit-forced'
+              }
+            ]
+      },
+      cancelDeployment: async () => {
+        throw new Error('cancel-deploy exited before the row settled')
+      },
+      fetchHealth: async () => ({
+        status: 200,
+        json: async () => ({
+          scenario: 'healthy',
+          healthValue: null,
+          INSTANCE_ID: 'instance-forced',
+          INSTANCE_TYPE: 'production',
+          CC_DEPLOYMENT_ID: 'deployment-forced',
+          CC_COMMIT_ID: 'commit-forced'
+        })
+      }),
+      sleep: async () => {},
+      settleTimeoutMs: 10_000,
+      pollIntervalMs: 1
+    })
+  ).resolves.toMatchObject({
+    outcome: 'cancelled',
+    deployment: { uuid: 'deployment-timeout', state: 'CANCELLED' },
+    health: { CC_COMMIT_ID: 'commit-forced' }
+  })
+
+  warnSpy.mockRestore()
+})
+
 test('verifies the prior app stays live when the timed-out deployment settles failed', async () => {
   await expect(
     cancelTimedOutDeploymentPreservesLiveApp({

--- a/src/e2e/deployment-observer.ts
+++ b/src/e2e/deployment-observer.ts
@@ -594,20 +594,25 @@ async function waitForSettledDeployment({
   for (;;) {
     throwIfDeadlineReached()
 
-    const deployment = (
-      await listActivity(
-        appId,
-        Math.min(
-          DEFAULT_HEALTH_CHECK_TIMEOUT_MS,
-          Math.max(1, remainingBeforeDeadline(deadlineAt))
-        )
+    const activity = await listActivity(
+      appId,
+      Math.min(
+        DEFAULT_HEALTH_CHECK_TIMEOUT_MS,
+        Math.max(1, remainingBeforeDeadline(deadlineAt))
       )
-    ).find(entry => entry.uuid === deploymentId)
+    )
+    const deployment = activity.find(entry => entry.uuid === deploymentId)
 
     throwIfDeadlineReached()
 
-    if (deployment && !isInProgressState(deployment.state)) {
+    if (deployment?.state && !isInProgressState(deployment.state)) {
       return deployment
+    }
+
+    // Clever removes the DEPLOY row of a cancelled deployment and replaces
+    // it with a CANCEL activity entry under a new uuid.
+    if (!deployment && hasSettledCancelActivity(activity)) {
+      return { uuid: deploymentId, action: 'DEPLOY', state: 'CANCELLED' }
     }
 
     await sleepUntilNextPoll({
@@ -616,6 +621,15 @@ async function waitForSettledDeployment({
       deadlineAt
     })
   }
+}
+
+function hasSettledCancelActivity(activity: DeploymentActivity[]): boolean {
+  return activity.some(
+    entry =>
+      entry.action === 'CANCEL' &&
+      Boolean(entry.state) &&
+      !isInProgressState(entry.state)
+  )
 }
 
 function isInProgressState(state: string | undefined): boolean {


### PR DESCRIPTION
Run seven still hung on the timeout-cancellation step, this time with #266 in place. Live inspection of the stuck app finally showed why every resolution attempt spins.

When Clever cancels a deployment mid-build, it does not mark the DEPLOY activity row as CANCELLED. It removes that row entirely and adds a CANCEL activity entry under a new uuid, with a null commit:

    { "uuid": "deployment_a23e...", "action": "CANCEL", "state": "OK", "commit": null }

Both settle waits poll the activity list for the original deployment uuid, so after a successful cancellation they look for a row that no longer exists and burn the whole observer budget. The cancellation itself works: the prior forced commit stayed live and healthy the entire time.

The fix teaches both waits about this shape. When the deployment row is gone and a settled CANCEL activity entry is present, the client and the observer classify the deployment as cancelled and move on to the prior-commit health checks. A row that is merely missing, with no CANCEL entry in sight, still polls to the deadline so a stale activity read cannot misclassify a live deployment.

Part of the qualification of the live e2e suite (acc-8cw7).
