### PR TITLE
chore: close out live suite qualification

### DIFF
--- a/.beans/acc-8cw7--commission-and-qualify-the-live-suite.md
+++ b/.beans/acc-8cw7--commission-and-qualify-the-live-suite.md
@@ -1,7 +1,7 @@
 ---
 # acc-8cw7
 title: Commission and qualify the live suite
-status: in-progress
+status: completed
 type: task
 priority: high
 tags:
@@ -26,12 +26,12 @@ Commission the protected environment and qualify the complete implementation aga
 
 ## Acceptance criteria
 
-- [ ] The protected environment contains the required secrets, region variable, approval rule, and no broader credential exposure.
-- [ ] One approved run completes every scenario in the PRD's required order, with timeout last.
-- [ ] The summary records the exact candidate SHA and digest plus successful exact-ID cleanup.
-- [ ] A controlled failing run proves safe evidence upload and teardown.
-- [ ] Public health output, artifacts, and fixture Git history contain no credential, unrelated environment value, or support file.
-- [ ] Every mismatch found during live qualification is fixed and the full run passes again before this task completes.
+- [x] The protected environment contains the required secrets, region variable, approval rule, and no broader credential exposure.
+- [x] One approved run completes every scenario in the PRD's required order, with timeout last.
+- [x] The summary records the exact candidate SHA and digest plus successful exact-ID cleanup.
+- [x] A controlled failing run proves safe evidence upload and teardown.
+- [x] Public health output, artifacts, and fixture Git history contain no credential, unrelated environment value, or support file.
+- [x] Every mismatch found during live qualification is fixed and the full run passes again before this task completes.
 
 ## User stories addressed
 
@@ -39,3 +39,16 @@ Commission the protected environment and qualify the complete implementation aga
 - User story 12
 - User story 15
 - User story 17 through user story 66
+
+## Summary of Changes
+
+Environment `clever-cloud-e2e` commissioned: reviewer franky47, `CLEVER_TOKEN`/`CLEVER_SECRET` secrets, `CLEVER_E2E_REGION=par`, no credential exposure outside the gated job. Clever deploy emails silenced through a scoped notify-email hook.
+
+Eight qualification runs against the live platform. Failing runs proved evidence upload (credential-free artifacts) and exact-ID teardown; runs six and seven exposed the last defect. Fixes merged during qualification:
+
+- #259, #260, #261, #263, #264: deploy URL resolution, teardown reliability, observer timeout budget, rejection wording, evidence handling.
+- #265: state-agnostic resolution of timed-out deployments in the observer.
+- #266: client-side cancellation accepts any settled state instead of insisting on CANCELLED, and the observer logs swallowed cancellation errors.
+- #267: Clever removes the DEPLOY activity row of a deployment cancelled mid-build and replaces it with a CANCEL entry under a new uuid; both settle waits now classify that shape as cancelled instead of polling for the vanished row until deadline.
+
+Qualifying run: https://github.com/47ng/actions-clever-cloud/actions/runs/30108430034 at baseline head f55e50a. All twelve scenarios green in PRD order, timeout last (`Timed-out deployment settled as cancelled`), summary records candidate SHA and digest, teardown deleted the exact app ID.

--- a/.beans/acc-9ddy--build-clever-cloud-end-to-end-deployment-suite.md
+++ b/.beans/acc-9ddy--build-clever-cloud-end-to-end-deployment-suite.md
@@ -1,7 +1,7 @@
 ---
 # acc-9ddy
 title: Build Clever Cloud end-to-end deployment suite
-status: todo
+status: completed
 type: epic
 priority: high
 created_at: 2026-07-23T11:00:31Z


### PR DESCRIPTION
The live suite is qualified. Run eight completed all twelve scenarios in the required order against Clever Cloud, with the timeout-cancellation step resolving cleanly at last (the deployment settled as cancelled and the prior forced commit stayed live).

This closes the qualification task with its acceptance record: environment commissioning, the fix trail (#259 through #267), and the qualifying run reference. With every child bean done, the parent epic closes too.

Closes acc-8cw7
Closes acc-9ddy
