### PR TITLE
fix: keep the deploy alive when a console log sink dies

### DIFF
--- a/src/output.test.ts
+++ b/src/output.test.ts
@@ -351,6 +351,50 @@ test('a console stream closed without error while backpressured fails the chain 
   )
 })
 
+test('a write after an errorless console close fails the chain instead of hanging', async () => {
+  const consoleStream = new Writable({
+    write(_chunk, _encoding, callback) {
+      callback()
+    }
+  })
+  const { stream, done } = await createDeployLog(
+    { quiet: false, consoleStream },
+    { warning }
+  )
+  stream.write(TS + 'first\n')
+  await new Promise(resolve => setImmediate(resolve))
+  consoleStream.destroy()
+  await new Promise(resolve => setImmediate(resolve))
+  stream.write(TS + 'second\n')
+  stream.end()
+  await expect(done()).resolves.toBeUndefined()
+  expect(warning).toHaveBeenCalledWith(
+    'deploy log output degraded (console): console stream closed while writing deploy logs'
+  )
+})
+
+test('an errorless console close that swallowed buffered output degrades instead of reporting success', async () => {
+  const consoleStream = new Writable({
+    write(_chunk, _encoding, _callback) {
+      // Never completes: the line stays in the buffer until destroy()
+      // discards it.
+    }
+  })
+  const { stream, done } = await createDeployLog(
+    { quiet: false, consoleStream },
+    { warning }
+  )
+  stream.write(TS + 'first\n')
+  await new Promise(resolve => setImmediate(resolve))
+  consoleStream.destroy()
+  await new Promise(resolve => setImmediate(resolve))
+  stream.end()
+  await expect(done()).resolves.toBeUndefined()
+  expect(warning).toHaveBeenCalledWith(
+    'deploy log output degraded (console): console stream closed while writing deploy logs'
+  )
+})
+
 test('destroying the deploy log stream settles done() instead of hanging', async () => {
   const logFile = tempLogFilePath('destroyed-tee')
   try {

--- a/src/output.test.ts
+++ b/src/output.test.ts
@@ -10,11 +10,6 @@ import {
   type DeployLog
 } from './output.ts'
 
-// createDeployLog tees its non-quiet output into the shared process.stdout.
-// This suite pipes into it repeatedly, which trips Node's 10-listener leak
-// warning without lifting the cap (see the same note in clever.test.ts).
-process.stdout.setMaxListeners(0)
-
 // --
 
 // A timestamp prefix in the shape the Clever CLI emits, asserted against the
@@ -146,8 +141,7 @@ test('logFile + non-quiet: the file gets the raw stream AND stdout gets the proc
   // injection: exactly the one line that was written, timestamp intact.
   expect(content).toBe(TS + '::notice ::Deployed!\n')
   // stdout receives the processed stream: the original line plus the
-  // injected (timestamp-stripped) annotation — two occurrences pin that
-  // both sinks actually fed off the same tee, not just one or the other.
+  // injected (timestamp-stripped) annotation.
   expect(capturedStdout().split('::notice ::Deployed!').length - 1).toBe(2)
   await fs.unlink(logFile)
 })
@@ -312,6 +306,66 @@ test('non-quiet without a log file: a dead console chain still drains the tee', 
     )
   } finally {
     decoderSpy.mockRestore()
+  }
+})
+
+test('a console stream dying while idle still degrades with a warning', async () => {
+  const consoleStream = new Writable({
+    write(_chunk, _encoding, callback) {
+      callback()
+    }
+  })
+  const { stream, done } = await createDeployLog(
+    { quiet: false, consoleStream },
+    { warning }
+  )
+  stream.write(TS + 'first\n')
+  await new Promise(resolve => setImmediate(resolve))
+  consoleStream.destroy(new Error('EPIPE while idle'))
+  await new Promise(resolve => setImmediate(resolve))
+  stream.end()
+  await expect(done()).resolves.toBeUndefined()
+  expect(warning).toHaveBeenCalledWith(
+    'deploy log output degraded (console): EPIPE while idle'
+  )
+})
+
+test('a console stream closed without error while backpressured fails the chain instead of hanging', async () => {
+  const consoleStream = new Writable({
+    highWaterMark: 1,
+    write(_chunk, _encoding, _callback) {
+      // Never completes: permanent backpressure.
+    }
+  })
+  const { stream, done } = await createDeployLog(
+    { quiet: false, consoleStream },
+    { warning }
+  )
+  stream.write(TS + 'first\n')
+  await new Promise(resolve => setImmediate(resolve))
+  consoleStream.destroy()
+  stream.end()
+  await expect(done()).resolves.toBeUndefined()
+  expect(warning).toHaveBeenCalledWith(
+    'deploy log output degraded (console): console stream closed while awaiting drain'
+  )
+})
+
+test('destroying the deploy log stream settles done() instead of hanging', async () => {
+  const logFile = tempLogFilePath('destroyed-tee')
+  try {
+    const { stream, done } = await deployLog(false, logFile)
+    stream.write(TS + 'first\n')
+    stream.destroy()
+    await expect(done()).resolves.toBeUndefined()
+    expect(warning).toHaveBeenCalledWith(
+      'deploy log output degraded (console): Premature close'
+    )
+    expect(warning).toHaveBeenCalledWith(
+      'deploy log output degraded (log file): Premature close'
+    )
+  } finally {
+    await fs.unlink(logFile)
   }
 })
 

--- a/src/output.test.ts
+++ b/src/output.test.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { Writable } from 'node:stream'
+import { StringDecoder } from 'node:string_decoder'
 import { afterEach, beforeEach, expect, test, vi } from 'vitest'
 import {
   createDeployLog,
@@ -163,20 +164,22 @@ test('quiet + logFile: file gets content, stdout gets nothing', async () => {
   await fs.unlink(logFile)
 })
 
-test('log file open failure degrades with a warning and keeps draining', async () => {
+test('log file open failure warns immediately and keeps draining', async () => {
   const openSpy = vi
     .spyOn(fs, 'open')
     .mockRejectedValue(new Error('ENOENT: missing directory'))
   try {
     const { stream, done } = await deployLog(true, '/missing/deploy.log')
+    // The warning fires at open time, not deferred until done(): a deploy
+    // that later hangs should still have surfaced the degraded log output.
+    expect(warning).toHaveBeenCalledWith(
+      'deploy log output degraded (log file): ENOENT: missing directory'
+    )
     for (let index = 0; index < 256; index += 1) {
       stream.write(Buffer.alloc(1024))
     }
     stream.end()
     await expect(done()).resolves.toBeUndefined()
-    expect(warning).toHaveBeenCalledWith(
-      'deploy log output degraded: ENOENT: missing directory'
-    )
   } finally {
     openSpy.mockRestore()
   }
@@ -205,11 +208,127 @@ test('log sink failure is handled early and later output keeps draining', async 
     stream.end()
     await expect(done()).resolves.toBeUndefined()
     expect(warning).toHaveBeenCalledWith(
-      'deploy log output degraded: disk full'
+      'deploy log output degraded (log file): disk full'
     )
   } finally {
     openSpy.mockRestore()
   }
+})
+
+// -- Console pipeline failure scenarios (issue #257) --
+
+function failingSink(message: string): Writable {
+  return new Writable({
+    highWaterMark: 1,
+    write(_chunk, _encoding, callback) {
+      callback(new Error(message))
+    }
+  })
+}
+
+test('non-quiet: a console stream write error degrades with a warning and keeps draining', async () => {
+  const consoleStream = failingSink('EPIPE: broken pipe')
+  const { stream, done } = await createDeployLog(
+    { quiet: false, consoleStream },
+    { warning }
+  )
+  stream.write(TS + 'first\n')
+  await new Promise(resolve => setImmediate(resolve))
+  for (let index = 0; index < 256; index += 1) {
+    stream.write(Buffer.alloc(1024))
+  }
+  stream.end()
+  await expect(done()).resolves.toBeUndefined()
+  expect(warning).toHaveBeenCalledWith(
+    'deploy log output degraded (console): EPIPE: broken pipe'
+  )
+})
+
+test('a mid-chain transform failure degrades console while the log file keeps writing', async () => {
+  const decoderSpy = vi
+    .spyOn(StringDecoder.prototype, 'write')
+    .mockImplementation(() => {
+      throw new Error('split boom')
+    })
+  const logFile = tempLogFilePath('mid-chain')
+  try {
+    const { stream, done } = await deployLog(false, logFile)
+    stream.write(TS + 'hello\n')
+    stream.end()
+    await expect(done()).resolves.toBeUndefined()
+    expect(warning).toHaveBeenCalledWith(
+      'deploy log output degraded (console): split boom'
+    )
+    const content = await fs.readFile(logFile, 'utf8')
+    expect(content).toBe(TS + 'hello\n')
+  } finally {
+    decoderSpy.mockRestore()
+    await fs.unlink(logFile)
+  }
+})
+
+test('a console stream dying under backpressure degrades while the log file keeps writing', async () => {
+  const consoleStream = failingSink('EPIPE: broken pipe')
+  const logFile = tempLogFilePath('backpressure')
+  try {
+    const { stream, done } = await createDeployLog(
+      { quiet: false, logFile, consoleStream },
+      { warning }
+    )
+    // Enough data to overwhelm every buffer between the tee and the dead
+    // chain: backpressure from the stalled console pipeline must not starve
+    // the healthy file sink.
+    const filler = (TS + 'x'.repeat(1017) + '\n').repeat(256)
+    stream.write(filler)
+    stream.end()
+    await expect(done()).resolves.toBeUndefined()
+    expect(warning).toHaveBeenCalledWith(
+      'deploy log output degraded (console): EPIPE: broken pipe'
+    )
+    const content = await fs.readFile(logFile, 'utf8')
+    expect(content).toBe(filler)
+  } finally {
+    await fs.unlink(logFile)
+  }
+})
+
+test('non-quiet without a log file: a dead console chain still drains the tee', async () => {
+  const decoderSpy = vi
+    .spyOn(StringDecoder.prototype, 'write')
+    .mockImplementation(() => {
+      throw new Error('split boom')
+    })
+  try {
+    const { stream, done } = await deployLog(false)
+    stream.write(TS + 'first\n')
+    await new Promise(resolve => setImmediate(resolve))
+    for (let index = 0; index < 256; index += 1) {
+      stream.write(Buffer.alloc(1024))
+    }
+    stream.end()
+    await expect(done()).resolves.toBeUndefined()
+    expect(warning).toHaveBeenCalledWith(
+      'deploy log output degraded (console): split boom'
+    )
+  } finally {
+    decoderSpy.mockRestore()
+  }
+})
+
+test('the console stream error listener is removed once the chain settles', async () => {
+  const consoleStream = new Writable({
+    write(_chunk, _encoding, callback) {
+      callback()
+    }
+  })
+  const { stream, done } = await createDeployLog(
+    { quiet: false, consoleStream },
+    { warning }
+  )
+  stream.write(TS + 'hello\n')
+  stream.end()
+  await done()
+  expect(consoleStream.listenerCount('error')).toBe(0)
 })
 
 test('non-quiet: adopts \\r\\n as the line separator once seen', async () => {

--- a/src/output.ts
+++ b/src/output.ts
@@ -93,56 +93,6 @@ export async function createDeployLog(
         }
       }
     }
-    const throwIfConsoleDead = (): void => {
-      if (consoleStream.errored) {
-        throw consoleStream.errored
-      }
-      // A console stream can die without an 'error' event (clean destroy,
-      // write-after-destroy): events alone cannot reveal that, so check
-      // state before trusting write() or waiting on 'drain'.
-      if (
-        consoleStream.closed ||
-        consoleStream.destroyed ||
-        consoleStream.writableEnded
-      ) {
-        throw new Error('console stream closed while writing deploy logs')
-      }
-    }
-    const waitForDrain = async (): Promise<void> => {
-      throwIfConsoleDead()
-      // once() rejects if 'error' fires while waiting, and racing 'close'
-      // covers a console stream destroyed without one — either way the chain
-      // fails instead of stalling on a 'drain' that never comes.
-      const abort = new AbortController()
-      try {
-        await Promise.race([
-          once(consoleStream, 'drain', { signal: abort.signal }),
-          once(consoleStream, 'close', { signal: abort.signal }).then(() => {
-            throw (
-              consoleStream.errored ??
-              new Error('console stream closed while awaiting drain')
-            )
-          })
-        ])
-      } finally {
-        abort.abort()
-      }
-    }
-    const writeLinesToConsole = async (
-      lines: AsyncIterable<string>
-    ): Promise<void> => {
-      for await (const line of lines) {
-        throwIfConsoleDead()
-        if (!consoleStream.write(line)) {
-          await waitForDrain()
-        }
-      }
-      // The no-op 'error' listener absorbs failures between writes; a console
-      // stream that died while idle must still fail the chain, or the error
-      // (and any output it swallowed with it) would vanish once the deploy
-      // ends without another line.
-      throwIfConsoleDead()
-    }
     // The console stream stays out of pipeline()'s custody: it is shared for
     // the whole action process lifetime and must survive this chain ending or
     // failing. chainInput takes the pipe instead, so a chain failure only
@@ -160,7 +110,7 @@ export async function createDeployLog(
       chainInput,
       splitNewlines,
       injectAnnotations,
-      writeLinesToConsole
+      lines => writeLinesToConsole(consoleStream, lines)
     ).finally(() => {
       consoleStream.off('error', onConsoleError)
     })
@@ -190,4 +140,58 @@ export async function createDeployLog(
     await Promise.all(completions)
   }
   return { stream: tee, done }
+}
+
+function throwIfConsoleDead(consoleStream: Writable): void {
+  if (consoleStream.errored) {
+    throw consoleStream.errored
+  }
+  // A console stream can die without an 'error' event (clean destroy,
+  // write-after-destroy): events alone cannot reveal that, so check
+  // state before trusting write() or waiting on 'drain'.
+  if (
+    consoleStream.closed ||
+    consoleStream.destroyed ||
+    consoleStream.writableEnded
+  ) {
+    throw new Error('console stream closed while writing deploy logs')
+  }
+}
+
+async function waitForDrain(consoleStream: Writable): Promise<void> {
+  throwIfConsoleDead(consoleStream)
+  // once() rejects if 'error' fires while waiting, and racing 'close'
+  // covers a console stream destroyed without one — either way the chain
+  // fails instead of stalling on a 'drain' that never comes.
+  const abort = new AbortController()
+  try {
+    await Promise.race([
+      once(consoleStream, 'drain', { signal: abort.signal }),
+      once(consoleStream, 'close', { signal: abort.signal }).then(() => {
+        throw (
+          consoleStream.errored ??
+          new Error('console stream closed while awaiting drain')
+        )
+      })
+    ])
+  } finally {
+    abort.abort()
+  }
+}
+
+async function writeLinesToConsole(
+  consoleStream: Writable,
+  lines: AsyncIterable<string>
+): Promise<void> {
+  for await (const line of lines) {
+    throwIfConsoleDead(consoleStream)
+    if (!consoleStream.write(line)) {
+      await waitForDrain(consoleStream)
+    }
+  }
+  // The no-op 'error' listener absorbs failures between writes; a console
+  // stream that died while idle must still fail the chain, or the error
+  // (and any output it swallowed with it) would vanish once the deploy
+  // ends without another line.
+  throwIfConsoleDead(consoleStream)
 }

--- a/src/output.ts
+++ b/src/output.ts
@@ -93,20 +93,43 @@ export async function createDeployLog(
         }
       }
     }
+    const waitForDrain = async (): Promise<void> => {
+      // once() rejects if 'error' fires while waiting, and racing 'close'
+      // covers a console stream destroyed without one — either way the chain
+      // fails instead of stalling on a 'drain' that never comes.
+      const abort = new AbortController()
+      try {
+        await Promise.race([
+          once(consoleStream, 'drain', { signal: abort.signal }),
+          once(consoleStream, 'close', { signal: abort.signal }).then(() => {
+            throw (
+              consoleStream.errored ??
+              new Error('console stream closed while awaiting drain')
+            )
+          })
+        ])
+      } finally {
+        abort.abort()
+      }
+    }
+    const throwIfConsoleErrored = (): void => {
+      if (consoleStream.errored) {
+        throw consoleStream.errored
+      }
+    }
     const writeLinesToConsole = async (
       lines: AsyncIterable<string>
     ): Promise<void> => {
       for await (const line of lines) {
-        if (consoleStream.errored) {
-          throw consoleStream.errored
-        }
+        throwIfConsoleErrored()
         if (!consoleStream.write(line)) {
-          // once() rejects if 'error' fires while waiting, so a console
-          // stream dying under backpressure (e.g. EPIPE) fails the chain
-          // instead of stalling it.
-          await once(consoleStream, 'drain')
+          await waitForDrain()
         }
       }
+      // The no-op 'error' listener absorbs failures between writes; a console
+      // stream that died while idle must still fail the chain, or the error
+      // would vanish once the deploy ends without another line.
+      throwIfConsoleErrored()
     }
     // The console stream stays out of pipeline()'s custody: it is shared for
     // the whole action process lifetime and must survive this chain ending or
@@ -119,7 +142,8 @@ export async function createDeployLog(
     const onConsoleError = (): void => {}
     consoleStream.on('error', onConsoleError)
     // pipeline() (unlike bare .pipe()) fails the whole chain when any stage
-    // fails, so this one completion sees every console failure mode.
+    // fails, so this one completion sees every console failure that occurs
+    // while the chain is live.
     const consoleDone = pipeline(
       chainInput,
       splitNewlines,
@@ -129,6 +153,9 @@ export async function createDeployLog(
       consoleStream.off('error', onConsoleError)
     })
     monitor('console', consoleDone, () => tee.unpipe(chainInput))
+    // A destroyed tee reaches no monitor on its own: chainInput would never
+    // end and done() would pend forever.
+    finished(tee).catch((error: Error) => chainInput.destroy(error))
   }
   if (logFile) {
     try {
@@ -137,6 +164,9 @@ export async function createDeployLog(
       monitor('log file', finished(logFileStream), () =>
         tee.unpipe(logFileStream)
       )
+      // Same tee-death guard as the console chain: without it a destroyed
+      // tee leaves the file stream unfinished and done() pending.
+      finished(tee).catch((error: Error) => logFileStream.destroy(error))
     } catch (error) {
       degrade('log file', error)
     }

--- a/src/output.ts
+++ b/src/output.ts
@@ -1,6 +1,7 @@
+import { once } from 'node:events'
 import fs from 'node:fs/promises'
-import { PassThrough, Transform, type Writable } from 'node:stream'
-import { finished } from 'node:stream/promises'
+import { PassThrough, type Writable } from 'node:stream'
+import { finished, pipeline } from 'node:stream/promises'
 import { StringDecoder } from 'node:string_decoder'
 import type { Host } from './github.ts'
 
@@ -13,26 +14,37 @@ export type DeployLog = {
    * Resolves once every sink fed by `stream` (the console pipeline, the log
    * file) has finished processing whatever was written before `stream.end()`
    * was called. A sink failing (e.g. ENOSPC, EPIPE) is reported via
-   * `host.warning` rather than rejecting — losing log output must never
-   * override the deploy's real outcome.
+   * `host.warning` at failure time rather than rejecting — losing log output
+   * must never override the deploy's real outcome.
    */
   done(): Promise<void>
 }
 
 export async function createDeployLog(
-  options: { quiet: boolean; logFile?: string },
+  options: { quiet: boolean; logFile?: string; consoleStream?: Writable },
   host: Pick<Host, 'warning'>
 ): Promise<DeployLog> {
-  const { quiet, logFile } = options
+  const { quiet, logFile, consoleStream = process.stdout } = options
   const tee = new PassThrough()
   const completions: Promise<void>[] = []
-  const completionErrors: unknown[] = []
   let liveSinkCount = 0
-  const monitor = (completion: Promise<void>): void => {
+  const degrade = (sink: string, error: unknown): void => {
+    host.warning(
+      `deploy log output degraded (${sink}): ${error instanceof Error ? error.message : String(error)}`
+    )
+  }
+  const monitor = (
+    sink: string,
+    completion: Promise<void>,
+    unpipeDeadSink: () => void
+  ): void => {
     liveSinkCount += 1
     completions.push(
       completion.catch(error => {
-        completionErrors.push(error)
+        degrade(sink, error)
+        // A dead sink must not hold the tee back through pipe backpressure:
+        // detach it so surviving sinks keep flowing.
+        unpipeDeadSink()
         liveSinkCount -= 1
         if (liveSinkCount === 0) {
           tee.resume()
@@ -81,21 +93,52 @@ export async function createDeployLog(
         }
       }
     }
-    const lastTransform = tee
-      .pipe(Transform.from(splitNewlines))
-      .pipe(Transform.from(injectAnnotations))
-    // `end: false`: process.stdout is shared for the whole action process
-    // lifetime — this tee ending must not close it.
-    lastTransform.pipe(process.stdout, { end: false })
-    monitor(finished(lastTransform))
+    const writeLinesToConsole = async (
+      lines: AsyncIterable<string>
+    ): Promise<void> => {
+      for await (const line of lines) {
+        if (consoleStream.errored) {
+          throw consoleStream.errored
+        }
+        if (!consoleStream.write(line)) {
+          // once() rejects if 'error' fires while waiting, so a console
+          // stream dying under backpressure (e.g. EPIPE) fails the chain
+          // instead of stalling it.
+          await once(consoleStream, 'drain')
+        }
+      }
+    }
+    // The console stream stays out of pipeline()'s custody: it is shared for
+    // the whole action process lifetime and must survive this chain ending or
+    // failing. chainInput takes the pipe instead, so a chain failure only
+    // costs the tee one unpipe.
+    const chainInput = new PassThrough()
+    tee.pipe(chainInput)
+    // An 'error' listener must exist between writes, or a console stream
+    // error would crash the process before writeLinesToConsole observes it.
+    const onConsoleError = (): void => {}
+    consoleStream.on('error', onConsoleError)
+    // pipeline() (unlike bare .pipe()) fails the whole chain when any stage
+    // fails, so this one completion sees every console failure mode.
+    const consoleDone = pipeline(
+      chainInput,
+      splitNewlines,
+      injectAnnotations,
+      writeLinesToConsole
+    ).finally(() => {
+      consoleStream.off('error', onConsoleError)
+    })
+    monitor('console', consoleDone, () => tee.unpipe(chainInput))
   }
   if (logFile) {
     try {
       const logFileStream = (await fs.open(logFile, 'w')).createWriteStream()
       tee.pipe(logFileStream)
-      monitor(finished(logFileStream))
+      monitor('log file', finished(logFileStream), () =>
+        tee.unpipe(logFileStream)
+      )
     } catch (error) {
-      completionErrors.push(error)
+      degrade('log file', error)
     }
   }
   if (liveSinkCount === 0) {
@@ -103,12 +146,6 @@ export async function createDeployLog(
   }
   const done = async (): Promise<void> => {
     await Promise.all(completions)
-    if (completionErrors.length > 0) {
-      const error = completionErrors[0]
-      host.warning(
-        `deploy log output degraded: ${error instanceof Error ? error.message : String(error)}`
-      )
-    }
   }
   return { stream: tee, done }
 }

--- a/src/output.ts
+++ b/src/output.ts
@@ -93,7 +93,23 @@ export async function createDeployLog(
         }
       }
     }
+    const throwIfConsoleDead = (): void => {
+      if (consoleStream.errored) {
+        throw consoleStream.errored
+      }
+      // A console stream can die without an 'error' event (clean destroy,
+      // write-after-destroy): events alone cannot reveal that, so check
+      // state before trusting write() or waiting on 'drain'.
+      if (
+        consoleStream.closed ||
+        consoleStream.destroyed ||
+        consoleStream.writableEnded
+      ) {
+        throw new Error('console stream closed while writing deploy logs')
+      }
+    }
     const waitForDrain = async (): Promise<void> => {
+      throwIfConsoleDead()
       // once() rejects if 'error' fires while waiting, and racing 'close'
       // covers a console stream destroyed without one — either way the chain
       // fails instead of stalling on a 'drain' that never comes.
@@ -112,24 +128,20 @@ export async function createDeployLog(
         abort.abort()
       }
     }
-    const throwIfConsoleErrored = (): void => {
-      if (consoleStream.errored) {
-        throw consoleStream.errored
-      }
-    }
     const writeLinesToConsole = async (
       lines: AsyncIterable<string>
     ): Promise<void> => {
       for await (const line of lines) {
-        throwIfConsoleErrored()
+        throwIfConsoleDead()
         if (!consoleStream.write(line)) {
           await waitForDrain()
         }
       }
       // The no-op 'error' listener absorbs failures between writes; a console
       // stream that died while idle must still fail the chain, or the error
-      // would vanish once the deploy ends without another line.
-      throwIfConsoleErrored()
+      // (and any output it swallowed with it) would vanish once the deploy
+      // ends without another line.
+      throwIfConsoleDead()
     }
     // The console stream stays out of pipeline()'s custody: it is shared for
     // the whole action process lifetime and must survive this chain ending or


### PR DESCRIPTION
The console pipeline was monitored only at its tail. A dead stdout, or an error in either transform, left the monitored promise pending while backpressure stalled the tee, so the deploy hung until the runner killed the job.

The issue suggested wrapping the Transform.from chain in stream.pipeline, but that cannot work: Duplex.from streams never finish destroy() while they are pumping, so the pipeline promise never settles. The transforms now run as bare async generator stages inside pipeline(), which owns their teardown, and a final stage writes to the console stream by hand. That stage throws when the stream has errored and waits for drain on backpressure, with once() rejecting if the stream dies while waiting.

A sink failure now warns at failure time, names the failing sink, unpipes the dead chain from the tee, and resumes the tee once no sinks remain. The log file open failure also warns immediately instead of after the deploy ends.

Each of the three hang scenarios has a test that times out against the old code.

Closes #257
