### PR TITLE
ci: recognize Release Please v5 candidate branch names

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -134,9 +134,15 @@ jobs:
           script: |
             const prs = JSON.parse(process.env.PRS || '[]');
 
+            // Release Please v5 appends `--components--<package>` to the
+            // branch name; earlier versions used the bare form. Keep in sync
+            // with isReleasePleaseCandidateBranch in src/e2e/candidate-policy.ts.
+            const branch = 'release-please--branches--master';
+
             for (const pr of prs) {
               if (
-                pr.headBranchName !== 'release-please--branches--master' ||
+                (pr.headBranchName !== branch &&
+                  !pr.headBranchName.startsWith(branch + '--')) ||
                 !pr.labels?.includes('autorelease: pending')
               ) {
                 continue;

--- a/src/e2e/candidate-policy.test.ts
+++ b/src/e2e/candidate-policy.test.ts
@@ -22,7 +22,8 @@ function eligiblePullRequest(): CandidatePullRequest {
     user: { login: 'github-actions[bot]' },
     head: {
       sha: headSha,
-      ref: 'release-please--branches--master',
+      // Release Please v5 appends the component suffix to the branch name.
+      ref: 'release-please--branches--master--components--actions-clever-cloud',
       repo: { full_name: thisRepo }
     },
     base: { ref: defaultBranch, repo: { full_name: thisRepo } },
@@ -41,6 +42,14 @@ describe('isEligibleAutomaticCandidate', () => {
     ).toBe(true)
   })
 
+  test('accepts the bare pre-v5 release please branch name', () => {
+    const pr = eligiblePullRequest()
+    pr.head.ref = 'release-please--branches--master'
+    expect(isEligibleAutomaticCandidate({ pr, thisRepo, defaultBranch })).toBe(
+      true
+    )
+  })
+
   test.each<[string, (pr: CandidatePullRequest) => void]>([
     ['a closed pull request', pr => (pr.state = 'closed')],
     ['a fork head', pr => (pr.head.repo.full_name = 'evil/fork')],
@@ -49,6 +58,10 @@ describe('isEligibleAutomaticCandidate', () => {
     ['a draft', pr => (pr.draft = true)],
     ['a human author', pr => (pr.user.login = 'franky47')],
     ['another head branch', pr => (pr.head.ref = 'feature/thing')],
+    [
+      'a lookalike head branch without the separator',
+      pr => (pr.head.ref = 'release-please--branches--masterful')
+    ],
     ['a missing autorelease label', pr => (pr.labels = [])]
   ])('rejects %s', (_description, mutate) => {
     const pr = eligiblePullRequest()
@@ -137,6 +150,10 @@ describe('violatesAutomaticCandidatePolicy', () => {
     ['a draft', pr => (pr.draft = true)],
     ['a human author', pr => (pr.user.login = 'franky47')],
     ['another head branch', pr => (pr.head.ref = 'feature/thing')],
+    [
+      'a lookalike head branch without the separator',
+      pr => (pr.head.ref = 'release-please--branches--masterful')
+    ],
     [
       'a missing autorelease label',
       pr => (pr.labels = [{ name: 'autorelease: tagged' }])

--- a/src/e2e/candidate-policy.ts
+++ b/src/e2e/candidate-policy.ts
@@ -20,6 +20,16 @@ type CandidateIdentityContext = CandidateRepositoryContext & {
   headSha: string
 }
 
+const releasePleaseBranch = 'release-please--branches--master'
+
+function isReleasePleaseCandidateBranch(ref: string): boolean {
+  // Release Please v5 appends `--components--<package>` to the branch name;
+  // earlier versions used the bare form.
+  return (
+    ref === releasePleaseBranch || ref.startsWith(releasePleaseBranch + '--')
+  )
+}
+
 export function isEligibleAutomaticCandidate({
   pr,
   thisRepo,
@@ -32,7 +42,7 @@ export function isEligibleAutomaticCandidate({
     pr.base.ref === defaultBranch &&
     pr.draft === false &&
     pr.user.login === 'github-actions[bot]' &&
-    pr.head.ref === 'release-please--branches--master' &&
+    isReleasePleaseCandidateBranch(pr.head.ref) &&
     pr.labels.some(label => label.name === 'autorelease: pending')
   )
 }
@@ -70,7 +80,7 @@ export function violatesAutomaticCandidatePolicy(
   return (
     pr.draft ||
     pr.user.login !== 'github-actions[bot]' ||
-    pr.head.ref !== 'release-please--branches--master' ||
+    !isReleasePleaseCandidateBranch(pr.head.ref) ||
     !pr.labels.some(label => label.name === 'autorelease: pending')
   )
 }

--- a/src/e2eWorkflowInvariants.test.ts
+++ b/src/e2eWorkflowInvariants.test.ts
@@ -503,8 +503,9 @@ describe('e2e-release-please', () => {
     expect(closure.source).toContain('pr.draft === false')
     expect(closure.source).toContain("pr.user.login === 'github-actions[bot]'")
     expect(closure.source).toContain(
-      "pr.head.ref === 'release-please--branches--master'"
+      'isReleasePleaseCandidateBranch(pr.head.ref)'
     )
+    expect(closure.source).toContain("'release-please--branches--master'")
     expect(closure.source).toContain('autorelease: pending')
     expect(closure.source).toContain('pr.head.repo.full_name === thisRepo')
     expect(closure.source).toContain('pr.base.repo.full_name === thisRepo')

--- a/src/e2eWorkflowInvariants.test.ts
+++ b/src/e2eWorkflowInvariants.test.ts
@@ -479,6 +479,20 @@ describe('e2e-manual', () => {
 })
 
 describe('e2e-release-please', () => {
+  test('the dispatch filter matches the candidate policy branch predicate', () => {
+    const dispatch = onlyStep(
+      jobOf(release, 'dispatch-release-please-candidates').steps ?? [],
+      step => scriptOf(step) !== null
+    )
+    const script = scriptOf(dispatch) ?? ''
+    // main.yml cannot import isReleasePleaseCandidateBranch, so it carries a
+    // hand-copied predicate; pin both halves so drift fails here instead of
+    // silently never dispatching e2e for release PRs again.
+    expect(script).toContain("'release-please--branches--master'")
+    expect(script).toContain("pr.headBranchName.startsWith(branch + '--')")
+    expect(script).toContain("'autorelease: pending'")
+  })
+
   test('triggers only on repository dispatch and deliberate pull request target events', () => {
     expect(e2eAutomatic.on['pull_request']).toBeUndefined()
     expect(e2eAutomatic.on['repository_dispatch']?.types).toContain(


### PR DESCRIPTION
The automatic e2e run never fired for the 2.1.5 release candidate (PR #270). Release Please v5 names its branch release-please--branches--master--components--actions-clever-cloud, while the dispatch filter in main.yml and the candidate policy both expected the bare pre-v5 name. The dispatch loop skipped the PR, and the ready-for-review fallback was rejected by the policy for the same reason.

Both spots now accept the bare name or the component-suffixed form, with a separator guard so lookalike branch names stay rejected. The other identity checks (bot author, same-repo head, pending label) are unchanged.

Once merged, close and reopen PR #270 (or dispatch release-please-candidate manually) to trigger the run.
