### PR TITLE
chore: compare e2e activity snapshots without depending on row order

### DIFF
--- a/src/e2e/deployment-observer.test.ts
+++ b/src/e2e/deployment-observer.test.ts
@@ -268,6 +268,101 @@ test('fails same-commit error and ignore checks when a new deploy activity appea
   )
 })
 
+test('confirms that reordered but otherwise unchanged activity is not a change', async () => {
+  const deploymentOne = {
+    action: 'DEPLOY',
+    state: 'OK',
+    uuid: 'deployment-1',
+    commit: 'commit-1'
+  }
+  const deploymentTwo = {
+    action: 'DEPLOY',
+    state: 'OK',
+    uuid: 'deployment-2',
+    commit: 'commit-2'
+  }
+  const previousActivity = [deploymentOne, deploymentTwo]
+  const reorderedActivity = [deploymentTwo, deploymentOne]
+
+  await expect(
+    confirmNoNewDeploymentActivity({
+      appId: 'app_facade42-cafe-babe-cafe-deadf00dbaad',
+      previousActivity,
+      listActivity: async () => reorderedActivity,
+      sleep: async () => {},
+      settleTimeoutMs: 2,
+      pollIntervalMs: 1
+    })
+  ).resolves.toEqual(reorderedActivity)
+})
+
+test('fails same-commit error and ignore checks when an additional deploy activity row appears among reordered rows', async () => {
+  const deploymentOne = {
+    action: 'DEPLOY',
+    state: 'OK',
+    uuid: 'deployment-1',
+    commit: 'commit-1'
+  }
+  const deploymentTwo = {
+    action: 'DEPLOY',
+    state: 'OK',
+    uuid: 'deployment-2',
+    commit: 'commit-2'
+  }
+  const previousActivity = [deploymentOne, deploymentTwo]
+  const activityWithExtraRow = [
+    {
+      action: 'DEPLOY',
+      state: 'WIP',
+      uuid: 'deployment-3',
+      commit: 'commit-3'
+    },
+    deploymentTwo,
+    deploymentOne
+  ]
+
+  await expect(
+    confirmNoNewDeploymentActivity({
+      appId: 'app_facade42-cafe-babe-cafe-deadf00dbaad',
+      previousActivity,
+      listActivity: async () => activityWithExtraRow,
+      sleep: async () => {},
+      settleTimeoutMs: 10_000,
+      pollIntervalMs: 1
+    })
+  ).rejects.toThrow('Observed unexpected deployment activity change')
+})
+
+test('fails same-commit error and ignore checks when an existing row changes state', async () => {
+  const previousActivity = [
+    {
+      action: 'DEPLOY',
+      state: 'WIP',
+      uuid: 'deployment-1',
+      commit: 'commit-1'
+    }
+  ]
+  const activityWithChangedState = [
+    {
+      action: 'DEPLOY',
+      state: 'OK',
+      uuid: 'deployment-1',
+      commit: 'commit-1'
+    }
+  ]
+
+  await expect(
+    confirmNoNewDeploymentActivity({
+      appId: 'app_facade42-cafe-babe-cafe-deadf00dbaad',
+      previousActivity,
+      listActivity: async () => activityWithChangedState,
+      sleep: async () => {},
+      settleTimeoutMs: 10_000,
+      pollIntervalMs: 1
+    })
+  ).rejects.toThrow('Observed unexpected deployment activity change')
+})
+
 test('confirms that a rejected divergent deploy leaves the prior healthy commit publicly visible', async () => {
   const baselineActivity = [
     {

--- a/src/e2e/deployment-observer.ts
+++ b/src/e2e/deployment-observer.ts
@@ -52,9 +52,7 @@ export async function confirmNoNewDeploymentActivity({
   pollIntervalMs?: number
 }): Promise<DeploymentActivity[]> {
   const deadlineAt = buildDeadline(settleTimeoutMs)
-  const previousSnapshot = sortedSnapshot(
-    previousActivity.map(serializeActivity)
-  )
+  const previousSnapshot = previousActivity.map(serializeActivity).toSorted()
 
   for (;;) {
     const activity = await listActivity(appId)
@@ -693,16 +691,12 @@ function hasMatchingActivitySnapshot(
 ): boolean {
   // Clever reorders activity rows and replaces them under new uuids, so row
   // order is not a signal; only the multiset of rows is.
-  const currentSnapshot = sortedSnapshot(activity.map(serializeActivity))
+  const currentSnapshot = activity.map(serializeActivity).toSorted()
 
   return (
     previousSnapshot.length === currentSnapshot.length &&
     previousSnapshot.every((entry, index) => entry === currentSnapshot[index])
   )
-}
-
-function sortedSnapshot(snapshot: string[]): string[] {
-  return [...snapshot].sort()
 }
 
 function isSuccessfulDeploymentState(state: string | undefined): boolean {

--- a/src/e2e/deployment-observer.ts
+++ b/src/e2e/deployment-observer.ts
@@ -52,7 +52,9 @@ export async function confirmNoNewDeploymentActivity({
   pollIntervalMs?: number
 }): Promise<DeploymentActivity[]> {
   const deadlineAt = buildDeadline(settleTimeoutMs)
-  const previousSnapshot = previousActivity.map(serializeActivity)
+  const previousSnapshot = sortedSnapshot(
+    previousActivity.map(serializeActivity)
+  )
 
   for (;;) {
     const activity = await listActivity(appId)
@@ -689,12 +691,18 @@ function hasMatchingActivitySnapshot(
   previousSnapshot: string[],
   activity: DeploymentActivity[]
 ): boolean {
-  const currentSnapshot = activity.map(serializeActivity)
+  // Clever reorders activity rows and replaces them under new uuids, so row
+  // order is not a signal; only the multiset of rows is.
+  const currentSnapshot = sortedSnapshot(activity.map(serializeActivity))
 
   return (
     previousSnapshot.length === currentSnapshot.length &&
     previousSnapshot.every((entry, index) => entry === currentSnapshot[index])
   )
+}
+
+function sortedSnapshot(snapshot: string[]): string[] {
+  return [...snapshot].sort()
 }
 
 function isSuccessfulDeploymentState(state: string | undefined): boolean {


### PR DESCRIPTION
Three scenarios prove a negative: that a deploy attempt changed nothing on Clever Cloud. The check compared the activity list position by position, so the same rows in a different order read as a change and failed the run.

Clever reorders activity rows and replaces them under new uuids. The suite already documents that for cancellation. Row order is not a signal; the set of rows is. Sorting both sides keeps every real signal, because each row serializes with its uuid: an added row, a changed state and a removed row all still fail, and there is a test for each.

Titled `chore` rather than `fix` because this touches only the e2e suite and should not cut a release.
