### PR TITLE
chore: define the e2e scenario catalogue once

### DIFF
--- a/src/e2e/scenario-catalogue.test.ts
+++ b/src/e2e/scenario-catalogue.test.ts
@@ -2,7 +2,11 @@ import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { expect, test } from 'vitest'
 import { parse } from 'yaml'
-import { SCENARIO_CATALOGUE, scenarioByName } from './scenario-catalogue.ts'
+import {
+  SCENARIO_CATALOGUE,
+  scenarioByName,
+  type ScenarioName
+} from './scenario-catalogue.ts'
 
 type Step = {
   id?: string
@@ -53,7 +57,7 @@ test('every catalogue entry has a matching action step in the workflow', () => {
 
 test('every candidate action step in the workflow has a catalogue entry', () => {
   expect(candidateActionSteps.length).toBe(SCENARIO_CATALOGUE.length)
-  const workflowStepIds = new Set(
+  const workflowStepIds: Set<string> = new Set(
     SCENARIO_CATALOGUE.map(scenario => scenario.workflowStepId)
   )
   for (const step of candidateActionSteps) {
@@ -102,7 +106,10 @@ test('names, log files, env names and step ids are each unique', () => {
 })
 
 test('scenarioByName throws on an unknown name', () => {
-  expect(() => scenarioByName('nope')).toThrow('Unknown E2E scenario: nope')
+  // Cast past the narrowed parameter type to exercise the runtime guard.
+  expect(() => scenarioByName('nope' as ScenarioName)).toThrow(
+    'Unknown E2E scenario: nope'
+  )
 })
 
 test('the timeout scenario is last', () => {

--- a/src/e2e/scenario-catalogue.test.ts
+++ b/src/e2e/scenario-catalogue.test.ts
@@ -1,0 +1,112 @@
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { expect, test } from 'vitest'
+import { parse } from 'yaml'
+import { SCENARIO_CATALOGUE, scenarioByName } from './scenario-catalogue.ts'
+
+type Step = {
+  id?: string
+  uses?: string
+  env?: Record<string, string>
+  with?: Record<string, unknown>
+}
+
+type Job = {
+  steps?: Step[]
+}
+
+type Workflow = {
+  jobs: Record<string, Job>
+}
+
+const workflowPath = fileURLToPath(
+  new URL('../../.github/workflows/e2e-reusable.yml', import.meta.url)
+)
+
+const workflow: Workflow = parse(readFileSync(workflowPath, 'utf8'))
+
+const suiteSteps: Step[] = workflow.jobs['create-and-delete']?.steps ?? []
+
+function envKeysOf(step: Step): string[] {
+  return Object.keys(step.env ?? {})
+}
+
+const candidateActionSteps: Step[] = suiteSteps.filter(
+  step => step.uses === './.candidate-action'
+)
+
+const teardownStep: Step | undefined = suiteSteps.find(step => {
+  const keys = envKeysOf(step)
+  return keys.includes('CLEVER_TOKEN') && keys.includes('E2E_HEALTH_VALUE')
+})
+
+test('every catalogue entry has a matching action step in the workflow', () => {
+  for (const scenario of SCENARIO_CATALOGUE) {
+    const step = suiteSteps.find(
+      candidate => candidate.id === scenario.workflowStepId
+    )
+    expect(step, `missing step ${scenario.workflowStepId}`).toBeDefined()
+    expect(step?.uses).toBe('./.candidate-action')
+    expect(step?.with?.['logFile']).toBe(`.e2e-artifacts/${scenario.logFile}`)
+  }
+})
+
+test('every candidate action step in the workflow has a catalogue entry', () => {
+  expect(candidateActionSteps.length).toBe(SCENARIO_CATALOGUE.length)
+  const workflowStepIds = new Set(
+    SCENARIO_CATALOGUE.map(scenario => scenario.workflowStepId)
+  )
+  for (const step of candidateActionSteps) {
+    const matches = SCENARIO_CATALOGUE.filter(
+      scenario => scenario.workflowStepId === step.id
+    )
+    expect(matches.length, `step id ${step.id}`).toBe(1)
+    expect(workflowStepIds.has(step.id ?? '')).toBe(true)
+  }
+})
+
+test("every catalogue entry's logPathEnvName is set on the teardown step, to the matching path", () => {
+  expect(teardownStep).toBeDefined()
+  for (const scenario of SCENARIO_CATALOGUE) {
+    expect(teardownStep?.env?.[scenario.logPathEnvName]).toBe(
+      '${{ github.workspace }}/.e2e-artifacts/' + scenario.logFile
+    )
+  }
+})
+
+test('the teardown step declares no *_LOG_PATH variable the catalogue does not know about', () => {
+  const teardownLogPathKeys = envKeysOf(teardownStep ?? {}).filter(key =>
+    key.endsWith('_LOG_PATH')
+  )
+  const catalogueLogPathEnvNames = SCENARIO_CATALOGUE.map(
+    scenario => scenario.logPathEnvName
+  )
+  expect(new Set(teardownLogPathKeys)).toEqual(
+    new Set(catalogueLogPathEnvNames)
+  )
+})
+
+test('names, log files, env names and step ids are each unique', () => {
+  expect(new Set(SCENARIO_CATALOGUE.map(scenario => scenario.name)).size).toBe(
+    SCENARIO_CATALOGUE.length
+  )
+  expect(
+    new Set(SCENARIO_CATALOGUE.map(scenario => scenario.logFile)).size
+  ).toBe(SCENARIO_CATALOGUE.length)
+  expect(
+    new Set(SCENARIO_CATALOGUE.map(scenario => scenario.logPathEnvName)).size
+  ).toBe(SCENARIO_CATALOGUE.length)
+  expect(
+    new Set(SCENARIO_CATALOGUE.map(scenario => scenario.workflowStepId)).size
+  ).toBe(SCENARIO_CATALOGUE.length)
+})
+
+test('scenarioByName throws on an unknown name', () => {
+  expect(() => scenarioByName('nope')).toThrow('Unknown E2E scenario: nope')
+})
+
+test('the timeout scenario is last', () => {
+  // The timeout case is placed last so its remote work cannot interfere
+  // with later deployment scenarios.
+  expect(SCENARIO_CATALOGUE.at(-1)?.name).toBe('timeout-cancelled')
+})

--- a/src/e2e/scenario-catalogue.ts
+++ b/src/e2e/scenario-catalogue.ts
@@ -5,7 +5,7 @@ export type ScenarioDefinition = {
   workflowStepId: string
 }
 
-export const SCENARIO_CATALOGUE: readonly ScenarioDefinition[] = [
+const scenarios = [
   {
     name: 'deploy-healthy-fixture-commit',
     logFile: 'candidate-action/001-deploy-healthy.log',
@@ -78,9 +78,18 @@ export const SCENARIO_CATALOGUE: readonly ScenarioDefinition[] = [
     logPathEnvName: 'TIMEOUT_LOG_PATH',
     workflowStepId: 'timeout-deploy'
   }
-]
+] as const
 
-export function scenarioByName(name: string): ScenarioDefinition {
+// isolatedDeclarations requires an explicit type annotation on the exported
+// binding, which would widen `name` back to `string` if applied directly to
+// the array above. Re-exporting it through this annotated binding keeps the
+// narrowed literal types available for `ScenarioName` below, while this
+// assignment still checks `scenarios` against `ScenarioDefinition`.
+export const SCENARIO_CATALOGUE: readonly ScenarioDefinition[] = scenarios
+
+export type ScenarioName = (typeof scenarios)[number]['name']
+
+export function scenarioByName(name: ScenarioName): ScenarioDefinition {
   const scenario = SCENARIO_CATALOGUE.find(entry => entry.name === name)
 
   if (!scenario) {

--- a/src/e2e/scenario-catalogue.ts
+++ b/src/e2e/scenario-catalogue.ts
@@ -1,11 +1,4 @@
-export type ScenarioDefinition = {
-  name: string
-  logFile: string
-  logPathEnvName: string
-  workflowStepId: string
-}
-
-const scenarios = [
+export const SCENARIO_CATALOGUE = [
   {
     name: 'deploy-healthy-fixture-commit',
     logFile: 'candidate-action/001-deploy-healthy.log',
@@ -80,14 +73,8 @@ const scenarios = [
   }
 ] as const
 
-// isolatedDeclarations requires an explicit type annotation on the exported
-// binding, which would widen `name` back to `string` if applied directly to
-// the array above. Re-exporting it through this annotated binding keeps the
-// narrowed literal types available for `ScenarioName` below, while this
-// assignment still checks `scenarios` against `ScenarioDefinition`.
-export const SCENARIO_CATALOGUE: readonly ScenarioDefinition[] = scenarios
-
-export type ScenarioName = (typeof scenarios)[number]['name']
+export type ScenarioDefinition = (typeof SCENARIO_CATALOGUE)[number]
+export type ScenarioName = ScenarioDefinition['name']
 
 export function scenarioByName(name: ScenarioName): ScenarioDefinition {
   const scenario = SCENARIO_CATALOGUE.find(entry => entry.name === name)

--- a/src/e2e/scenario-catalogue.ts
+++ b/src/e2e/scenario-catalogue.ts
@@ -1,0 +1,91 @@
+export type ScenarioDefinition = {
+  name: string
+  logFile: string
+  logPathEnvName: string
+  workflowStepId: string
+}
+
+export const SCENARIO_CATALOGUE: readonly ScenarioDefinition[] = [
+  {
+    name: 'deploy-healthy-fixture-commit',
+    logFile: 'candidate-action/001-deploy-healthy.log',
+    logPathEnvName: 'HEALTHY_LOG_PATH',
+    workflowStepId: 'deploy-healthy'
+  },
+  {
+    name: 'deploy-healthy-fixture-env-check',
+    logFile: 'candidate-action/002-deploy-env.log',
+    logPathEnvName: 'ENV_LOG_PATH',
+    workflowStepId: 'deploy-env'
+  },
+  {
+    name: 'same-commit-error',
+    logFile: 'candidate-action/003-same-commit-error.log',
+    logPathEnvName: 'SAME_COMMIT_ERROR_LOG_PATH',
+    workflowStepId: 'same-commit-error'
+  },
+  {
+    name: 'same-commit-ignore',
+    logFile: 'candidate-action/004-same-commit-ignore.log',
+    logPathEnvName: 'SAME_COMMIT_IGNORE_LOG_PATH',
+    workflowStepId: 'same-commit-ignore'
+  },
+  {
+    name: 'same-commit-restart',
+    logFile: 'candidate-action/005-same-commit-restart.log',
+    logPathEnvName: 'SAME_COMMIT_RESTART_LOG_PATH',
+    workflowStepId: 'same-commit-restart'
+  },
+  {
+    name: 'same-commit-rebuild',
+    logFile: 'candidate-action/006-same-commit-rebuild.log',
+    logPathEnvName: 'SAME_COMMIT_REBUILD_LOG_PATH',
+    workflowStepId: 'same-commit-rebuild'
+  },
+  {
+    name: 'build-failure',
+    logFile: 'candidate-action/007-build-failure.log',
+    logPathEnvName: 'BUILD_FAILURE_LOG_PATH',
+    workflowStepId: 'build-failure'
+  },
+  {
+    name: 'startup-failure',
+    logFile: 'candidate-action/008-startup-failure.log',
+    logPathEnvName: 'STARTUP_FAILURE_LOG_PATH',
+    workflowStepId: 'startup-failure'
+  },
+  {
+    name: 'recovery',
+    logFile: 'candidate-action/009-recovery.log',
+    logPathEnvName: 'RECOVERY_LOG_PATH',
+    workflowStepId: 'recovery'
+  },
+  {
+    name: 'divergent-no-force',
+    logFile: 'candidate-action/010-divergent-no-force.log',
+    logPathEnvName: 'DIVERGENT_NO_FORCE_LOG_PATH',
+    workflowStepId: 'divergent-no-force'
+  },
+  {
+    name: 'divergent-force',
+    logFile: 'candidate-action/011-divergent-force.log',
+    logPathEnvName: 'DIVERGENT_FORCE_LOG_PATH',
+    workflowStepId: 'divergent-force'
+  },
+  {
+    name: 'timeout-cancelled',
+    logFile: 'candidate-action/012-timeout.log',
+    logPathEnvName: 'TIMEOUT_LOG_PATH',
+    workflowStepId: 'timeout-deploy'
+  }
+]
+
+export function scenarioByName(name: string): ScenarioDefinition {
+  const scenario = SCENARIO_CATALOGUE.find(entry => entry.name === name)
+
+  if (!scenario) {
+    throw new Error(`Unknown E2E scenario: ${name}`)
+  }
+
+  return scenario
+}

--- a/src/e2e/scripts/delete-app-and-prepare-evidence.ts
+++ b/src/e2e/scripts/delete-app-and-prepare-evidence.ts
@@ -5,24 +5,13 @@ import {
   prepareFailureEvidence,
   verifyPreparedFailureEvidence
 } from '../evidence.ts'
+import { SCENARIO_CATALOGUE } from '../scenario-catalogue.ts'
 import { createRunCommand, resolveCleverCLI } from '../workflow-adapters.ts'
 
 const githubOutput = process.env.GITHUB_OUTPUT
 const hasAppIdFile = process.env.HAS_APP_ID_FILE === 'true'
 const outputDir = process.env.OUTPUT_DIR
 const resultsPath = process.env.RESULTS_PATH
-const healthyLogPath = process.env.HEALTHY_LOG_PATH
-const envLogPath = process.env.ENV_LOG_PATH
-const sameCommitErrorLogPath = process.env.SAME_COMMIT_ERROR_LOG_PATH
-const sameCommitIgnoreLogPath = process.env.SAME_COMMIT_IGNORE_LOG_PATH
-const sameCommitRestartLogPath = process.env.SAME_COMMIT_RESTART_LOG_PATH
-const sameCommitRebuildLogPath = process.env.SAME_COMMIT_REBUILD_LOG_PATH
-const buildFailureLogPath = process.env.BUILD_FAILURE_LOG_PATH
-const startupFailureLogPath = process.env.STARTUP_FAILURE_LOG_PATH
-const recoveryLogPath = process.env.RECOVERY_LOG_PATH
-const divergentNoForceLogPath = process.env.DIVERGENT_NO_FORCE_LOG_PATH
-const divergentForceLogPath = process.env.DIVERGENT_FORCE_LOG_PATH
-const timeoutLogPath = process.env.TIMEOUT_LOG_PATH
 const token = process.env.CLEVER_TOKEN
 const secret = process.env.CLEVER_SECRET
 const healthValue = process.env.E2E_HEALTH_VALUE
@@ -31,26 +20,21 @@ let appName = process.env.APP_NAME
 const appIdFile = process.env.APP_ID_FILE
 const cleverCLI = resolveCleverCLI()
 
-if (
-  !outputDir ||
-  !resultsPath ||
-  !healthyLogPath ||
-  !envLogPath ||
-  !sameCommitErrorLogPath ||
-  !sameCommitIgnoreLogPath ||
-  !sameCommitRestartLogPath ||
-  !sameCommitRebuildLogPath ||
-  !buildFailureLogPath ||
-  !startupFailureLogPath ||
-  !recoveryLogPath ||
-  !divergentNoForceLogPath ||
-  !divergentForceLogPath ||
-  !timeoutLogPath ||
-  !token ||
-  !secret
-) {
+if (!outputDir || !resultsPath || !token || !secret) {
   throw new Error('Missing teardown or failure evidence inputs')
 }
+
+const scenarioLogPaths = SCENARIO_CATALOGUE.map(scenario => {
+  const sourcePath = process.env[scenario.logPathEnvName]
+
+  if (!sourcePath) {
+    throw new Error(
+      `Missing ${scenario.logPathEnvName} for scenario ${scenario.name}`
+    )
+  }
+
+  return { sourcePath, artifactPath: scenario.logFile }
+})
 
 function messageFrom(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
@@ -66,56 +50,7 @@ const buildEvidenceCandidates = async (): Promise<
     }
   ]
 
-  for (const logCandidate of [
-    {
-      sourcePath: healthyLogPath,
-      artifactPath: 'candidate-action/001-deploy-healthy.log'
-    },
-    {
-      sourcePath: envLogPath,
-      artifactPath: 'candidate-action/002-deploy-env.log'
-    },
-    {
-      sourcePath: sameCommitErrorLogPath,
-      artifactPath: 'candidate-action/003-same-commit-error.log'
-    },
-    {
-      sourcePath: sameCommitIgnoreLogPath,
-      artifactPath: 'candidate-action/004-same-commit-ignore.log'
-    },
-    {
-      sourcePath: sameCommitRestartLogPath,
-      artifactPath: 'candidate-action/005-same-commit-restart.log'
-    },
-    {
-      sourcePath: sameCommitRebuildLogPath,
-      artifactPath: 'candidate-action/006-same-commit-rebuild.log'
-    },
-    {
-      sourcePath: buildFailureLogPath,
-      artifactPath: 'candidate-action/007-build-failure.log'
-    },
-    {
-      sourcePath: startupFailureLogPath,
-      artifactPath: 'candidate-action/008-startup-failure.log'
-    },
-    {
-      sourcePath: recoveryLogPath,
-      artifactPath: 'candidate-action/009-recovery.log'
-    },
-    {
-      sourcePath: divergentNoForceLogPath,
-      artifactPath: 'candidate-action/010-divergent-no-force.log'
-    },
-    {
-      sourcePath: divergentForceLogPath,
-      artifactPath: 'candidate-action/011-divergent-force.log'
-    },
-    {
-      sourcePath: timeoutLogPath,
-      artifactPath: 'candidate-action/012-timeout.log'
-    }
-  ]) {
+  for (const logCandidate of scenarioLogPaths) {
     try {
       await access(logCandidate.sourcePath, constants.F_OK)
       candidates.push(logCandidate)

--- a/src/e2e/scripts/write-suite-results.ts
+++ b/src/e2e/scripts/write-suite-results.ts
@@ -5,6 +5,7 @@ import {
   buildSuiteResults,
   writeSuiteResults
 } from '../evidence.ts'
+import { scenarioByName } from '../scenario-catalogue.ts'
 
 const appIdFile = process.env.APP_ID_FILE
 const resultsPath = process.env.RESULTS_PATH
@@ -69,7 +70,9 @@ await writeSuiteResults(
           process.env.HEALTHY_COMMIT ||
           null,
         deploymentId: process.env.HEALTHY_OBSERVED_DEPLOYMENT_ID || null,
-        candidateActionLogs: ['candidate-action/001-deploy-healthy.log']
+        candidateActionLogs: [
+          scenarioByName('deploy-healthy-fixture-commit').logFile
+        ]
       },
       {
         name: 'deploy-healthy-fixture-env-check',
@@ -83,7 +86,9 @@ await writeSuiteResults(
         commitId:
           process.env.ENV_OBSERVED_COMMIT_ID || process.env.ENV_COMMIT || null,
         deploymentId: process.env.ENV_OBSERVED_DEPLOYMENT_ID || null,
-        candidateActionLogs: ['candidate-action/002-deploy-env.log']
+        candidateActionLogs: [
+          scenarioByName('deploy-healthy-fixture-env-check').logFile
+        ]
       },
       {
         name: 'same-commit-error',
@@ -96,7 +101,7 @@ await writeSuiteResults(
         instanceId: process.env.SAME_COMMIT_BASELINE_INSTANCE_ID || null,
         commitId: process.env.SAME_COMMIT_BASELINE_COMMIT_ID || null,
         deploymentId: null,
-        candidateActionLogs: ['candidate-action/003-same-commit-error.log']
+        candidateActionLogs: [scenarioByName('same-commit-error').logFile]
       },
       {
         name: 'same-commit-ignore',
@@ -118,7 +123,7 @@ await writeSuiteResults(
           process.env.SAME_COMMIT_IGNORE_DEPLOYMENT_ID ||
           process.env.SAME_COMMIT_BASELINE_DEPLOYMENT_ID ||
           null,
-        candidateActionLogs: ['candidate-action/004-same-commit-ignore.log']
+        candidateActionLogs: [scenarioByName('same-commit-ignore').logFile]
       },
       {
         name: 'same-commit-restart',
@@ -131,7 +136,7 @@ await writeSuiteResults(
         instanceId: process.env.SAME_COMMIT_RESTART_INSTANCE_ID || null,
         commitId: process.env.SAME_COMMIT_RESTART_COMMIT_ID || null,
         deploymentId: process.env.SAME_COMMIT_RESTART_DEPLOYMENT_ID || null,
-        candidateActionLogs: ['candidate-action/005-same-commit-restart.log']
+        candidateActionLogs: [scenarioByName('same-commit-restart').logFile]
       },
       {
         name: 'same-commit-rebuild',
@@ -144,7 +149,7 @@ await writeSuiteResults(
         instanceId: process.env.SAME_COMMIT_REBUILD_INSTANCE_ID || null,
         commitId: process.env.SAME_COMMIT_REBUILD_COMMIT_ID || null,
         deploymentId: process.env.SAME_COMMIT_REBUILD_DEPLOYMENT_ID || null,
-        candidateActionLogs: ['candidate-action/006-same-commit-rebuild.log']
+        candidateActionLogs: [scenarioByName('same-commit-rebuild').logFile]
       },
       {
         name: 'build-failure',
@@ -157,7 +162,7 @@ await writeSuiteResults(
         instanceId: process.env.BUILD_FAILURE_INSTANCE_ID || null,
         commitId: process.env.BUILD_FAILURE_COMMIT || null,
         deploymentId: process.env.BUILD_FAILURE_DEPLOYMENT_ID || null,
-        candidateActionLogs: ['candidate-action/007-build-failure.log']
+        candidateActionLogs: [scenarioByName('build-failure').logFile]
       },
       {
         name: 'startup-failure',
@@ -170,7 +175,7 @@ await writeSuiteResults(
         instanceId: process.env.STARTUP_FAILURE_INSTANCE_ID || null,
         commitId: process.env.STARTUP_FAILURE_COMMIT || null,
         deploymentId: process.env.STARTUP_FAILURE_DEPLOYMENT_ID || null,
-        candidateActionLogs: ['candidate-action/008-startup-failure.log']
+        candidateActionLogs: [scenarioByName('startup-failure').logFile]
       },
       {
         name: 'recovery',
@@ -184,7 +189,7 @@ await writeSuiteResults(
         commitId:
           process.env.RECOVERY_COMMIT_ID || process.env.RECOVERY_COMMIT || null,
         deploymentId: process.env.RECOVERY_DEPLOYMENT_ID || null,
-        candidateActionLogs: ['candidate-action/009-recovery.log']
+        candidateActionLogs: [scenarioByName('recovery').logFile]
       },
       {
         name: 'divergent-no-force',
@@ -199,7 +204,7 @@ await writeSuiteResults(
           null,
         commitId: process.env.DIVERGENT_NO_FORCE_COMMIT_ID || null,
         deploymentId: process.env.DIVERGENT_NO_FORCE_DEPLOYMENT_ID || null,
-        candidateActionLogs: ['candidate-action/010-divergent-no-force.log']
+        candidateActionLogs: [scenarioByName('divergent-no-force').logFile]
       },
       {
         name: 'divergent-force',
@@ -214,7 +219,7 @@ await writeSuiteResults(
           process.env.DIVERGENT_FORCE_COMMIT ||
           null,
         deploymentId: process.env.DIVERGENT_FORCE_DEPLOYMENT_ID || null,
-        candidateActionLogs: ['candidate-action/011-divergent-force.log']
+        candidateActionLogs: [scenarioByName('divergent-force').logFile]
       },
       {
         name: 'timeout-cancelled',
@@ -231,7 +236,7 @@ await writeSuiteResults(
         commitId:
           process.env.TIMEOUT_COMMIT_ID || process.env.TIMEOUT_COMMIT || null,
         deploymentId: process.env.TIMEOUT_DEPLOYMENT_ID || null,
-        candidateActionLogs: ['candidate-action/012-timeout.log']
+        candidateActionLogs: [scenarioByName('timeout-cancelled').logFile]
       }
     ]
   })


### PR DESCRIPTION
The suite's twelve scenarios each existed by hand in four places: the workflow, the results writer, the teardown evidence list and the docs. Nothing checked that they agreed, so adding one meant editing three files in lockstep, and a typo produced a null in the summary rather than a failure.

One catalogue now feeds the two scripts, and a test parses the workflow and cross-checks both directions. A scenario present in one but not the other fails in seconds. Scenario names are a literal union derived from the catalogue, so a misspelled lookup is a compile error instead of a throw forty minutes into a credentialed live run.

The workflow file is deliberately untouched. It stays the source of truth the catalogue is checked against. Collapsing its repetition is the larger half of this, and its only real verification is a live run.
