### PR TITLE
chore: write e2e step outputs through a delimiter-safe helper

### DIFF
--- a/src/e2e/scripts/assert-build-failure.ts
+++ b/src/e2e/scripts/assert-build-failure.ts
@@ -1,10 +1,11 @@
-import { appendFile, readFile } from 'node:fs/promises'
+import { readFile } from 'node:fs/promises'
 import { createCleverController } from '../clever-client.ts'
 import {
   waitForHealthyDeployment,
   waitForNewFailedDeploymentActivity
 } from '../deployment-observer.ts'
 import { FIXTURE_BUILD_FAILURE_MARKER } from '../fixture-app.ts'
+import { writeStepOutputs } from '../step-output.ts'
 import {
   createFetchHealth,
   createRunCommand,
@@ -74,9 +75,8 @@ if (!logContent.includes(FIXTURE_BUILD_FAILURE_MARKER)) {
   )
 }
 
-await appendFile(
-  githubOutput,
-  `instance_id=${health.INSTANCE_ID ?? ''}\n` +
-    `deployment_id=${failedDeployment.uuid ?? ''}\n` +
-    `commit_id=${failedDeployment.commit ?? expectedCommitID}\n`
-)
+await writeStepOutputs(githubOutput, {
+  instance_id: health.INSTANCE_ID,
+  deployment_id: failedDeployment.uuid,
+  commit_id: failedDeployment.commit ?? expectedCommitID
+})

--- a/src/e2e/scripts/assert-divergent-rejection.ts
+++ b/src/e2e/scripts/assert-divergent-rejection.ts
@@ -1,6 +1,7 @@
-import { appendFile, readFile } from 'node:fs/promises'
+import { readFile } from 'node:fs/promises'
 import { createCleverController } from '../clever-client.ts'
 import { confirmRejectedDeploymentPreservesLiveApp } from '../deployment-observer.ts'
+import { writeStepOutputs } from '../step-output.ts'
 import {
   createFetchHealth,
   createRunCommand,
@@ -76,9 +77,8 @@ if (!nonFastForwardMarkers.some(marker => logContent.includes(marker))) {
   )
 }
 
-await appendFile(
-  githubOutput,
-  `instance_id=${health.INSTANCE_ID ?? ''}\n` +
-    `deployment_id=${health.CC_DEPLOYMENT_ID ?? ''}\n` +
-    `commit_id=${health.CC_COMMIT_ID ?? ''}\n`
-)
+await writeStepOutputs(githubOutput, {
+  instance_id: health.INSTANCE_ID,
+  deployment_id: health.CC_DEPLOYMENT_ID,
+  commit_id: health.CC_COMMIT_ID
+})

--- a/src/e2e/scripts/assert-startup-failure.ts
+++ b/src/e2e/scripts/assert-startup-failure.ts
@@ -1,10 +1,11 @@
-import { appendFile, readFile } from 'node:fs/promises'
+import { readFile } from 'node:fs/promises'
 import { createCleverController } from '../clever-client.ts'
 import {
   waitForHealthyDeployment,
   waitForNewFailedDeploymentActivity
 } from '../deployment-observer.ts'
 import { FIXTURE_STARTUP_FAILURE_MARKER } from '../fixture-app.ts'
+import { writeStepOutputs } from '../step-output.ts'
 import {
   createFetchHealth,
   createRunCommand,
@@ -74,9 +75,8 @@ if (!logContent.includes(FIXTURE_STARTUP_FAILURE_MARKER)) {
   )
 }
 
-await appendFile(
-  githubOutput,
-  `instance_id=${health.INSTANCE_ID ?? ''}\n` +
-    `deployment_id=${failedDeployment.uuid ?? ''}\n` +
-    `commit_id=${failedDeployment.commit ?? expectedCommitID}\n`
-)
+await writeStepOutputs(githubOutput, {
+  instance_id: health.INSTANCE_ID,
+  deployment_id: failedDeployment.uuid,
+  commit_id: failedDeployment.commit ?? expectedCommitID
+})

--- a/src/e2e/scripts/build-app-name.ts
+++ b/src/e2e/scripts/build-app-name.ts
@@ -1,5 +1,5 @@
-import { appendFile } from 'node:fs/promises'
 import { buildE2EApplicationName } from '../clever-client.ts'
+import { writeStepOutputs } from '../step-output.ts'
 
 const runId = process.env.RUN_ID
 const runAttempt = process.env.RUN_ATTEMPT
@@ -10,4 +10,4 @@ if (!runId || !runAttempt || !githubOutput) {
 }
 
 const name = buildE2EApplicationName({ runId, runAttempt })
-await appendFile(githubOutput, `name=${name}\n`)
+await writeStepOutputs(githubOutput, { name })

--- a/src/e2e/scripts/capture-release-candidate-identity.ts
+++ b/src/e2e/scripts/capture-release-candidate-identity.ts
@@ -4,6 +4,7 @@ import {
   isEligibleAutomaticCandidate
 } from '../candidate-policy.ts'
 import { createGitHubClient } from '../github-api.ts'
+import { writeStepOutputs } from '../step-output.ts'
 
 const prNumber = Number(process.env.PR_NUMBER)
 const token = process.env.GH_TOKEN
@@ -31,14 +32,13 @@ const defaultBranch = event.repository.default_branch
 const github = createGitHubClient({ token, repository: thisRepo })
 const pr = await github.getPullRequest(prNumber)
 
-await appendFile(
-  githubOutput,
-  `pr_number=${String(pr.number)}\n` +
-    `candidate_source_repository=${thisRepo}\n`
-)
+await writeStepOutputs(githubOutput, {
+  pr_number: String(pr.number),
+  candidate_source_repository: thisRepo
+})
 
 if (!isEligibleAutomaticCandidate({ pr, thisRepo, defaultBranch })) {
-  await appendFile(githubOutput, 'proceed=false\n')
+  await writeStepOutputs(githubOutput, { proceed: 'false' })
   await appendFile(
     stepSummary,
     buildSupersededSummary(
@@ -48,4 +48,7 @@ if (!isEligibleAutomaticCandidate({ pr, thisRepo, defaultBranch })) {
   process.exit(0)
 }
 
-await appendFile(githubOutput, `proceed=true\n` + `head_sha=${pr.head.sha}\n`)
+await writeStepOutputs(githubOutput, {
+  proceed: 'true',
+  head_sha: pr.head.sha
+})

--- a/src/e2e/scripts/create-divergent-fixture-commit.ts
+++ b/src/e2e/scripts/create-divergent-fixture-commit.ts
@@ -1,5 +1,5 @@
-import { appendFile } from 'node:fs/promises'
 import { createDivergentFixtureCommit } from '../git-fixture.ts'
+import { writeStepOutputs } from '../step-output.ts'
 
 const workspaceDir = process.env.WORKSPACE_DIR
 const ancestorCommit = process.env.ANCESTOR_COMMIT
@@ -15,4 +15,4 @@ const commit = await createDivergentFixtureCommit({
   label: 'healthy-force'
 })
 
-await appendFile(githubOutput, `commit=${commit}\n`)
+await writeStepOutputs(githubOutput, { commit })

--- a/src/e2e/scripts/create-e2e-app.ts
+++ b/src/e2e/scripts/create-e2e-app.ts
@@ -1,9 +1,10 @@
-import { appendFile, mkdir, writeFile } from 'node:fs/promises'
+import { mkdir, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 import {
   createApplicationWithRecovery,
   createCleverController
 } from '../clever-client.ts'
+import { writeStepOutputs } from '../step-output.ts'
 import { createRunCommand, resolveCleverCLI } from '../workflow-adapters.ts'
 
 const githubOutput = process.env.GITHUB_OUTPUT
@@ -32,10 +33,10 @@ const application = await createApplicationWithRecovery(controller, {
 
 try {
   await writeFile(appIdFile, JSON.stringify(application), 'utf8')
-  await appendFile(
-    githubOutput,
-    `app_id=${application.appId}\n` + `app_name=${application.name}\n`
-  )
+  await writeStepOutputs(githubOutput, {
+    app_id: application.appId,
+    app_name: application.name
+  })
 } catch (error) {
   try {
     await controller.deleteApplication({

--- a/src/e2e/scripts/create-fixture-commit.ts
+++ b/src/e2e/scripts/create-fixture-commit.ts
@@ -1,5 +1,5 @@
-import { appendFile } from 'node:fs/promises'
 import { createHealthyFixtureCommit } from '../git-fixture.ts'
+import { writeStepOutputs } from '../step-output.ts'
 
 const workspaceDir = process.env.WORKSPACE_DIR
 const commitLabel = process.env.COMMIT_LABEL
@@ -15,4 +15,4 @@ const commit = await createHealthyFixtureCommit({
   label: commitLabel
 })
 
-await appendFile(githubOutput, `commit=${commit}\n`)
+await writeStepOutputs(githubOutput, { commit })

--- a/src/e2e/scripts/create-fixture-repository.ts
+++ b/src/e2e/scripts/create-fixture-repository.ts
@@ -1,5 +1,5 @@
-import { appendFile } from 'node:fs/promises'
 import { createFixtureRepository } from '../git-fixture.ts'
+import { writeStepOutputs } from '../step-output.ts'
 
 const workspaceDir = process.env.WORKSPACE_DIR
 const githubOutput = process.env.GITHUB_OUTPUT
@@ -8,4 +8,4 @@ if (!workspaceDir || !githubOutput) {
 }
 
 const fixture = await createFixtureRepository({ workspaceDir })
-await appendFile(githubOutput, `commit=${fixture.commit}\n`)
+await writeStepOutputs(githubOutput, { commit: fixture.commit })

--- a/src/e2e/scripts/delete-app-and-prepare-evidence.ts
+++ b/src/e2e/scripts/delete-app-and-prepare-evidence.ts
@@ -1,10 +1,11 @@
 import { constants } from 'node:fs'
-import { access, appendFile, readFile } from 'node:fs/promises'
+import { access, readFile } from 'node:fs/promises'
 import { APP_ID_REGEX, createCleverController } from '../clever-client.ts'
 import {
   prepareFailureEvidence,
   verifyPreparedFailureEvidence
 } from '../evidence.ts'
+import { writeStepOutputs } from '../step-output.ts'
 import { createRunCommand, resolveCleverCLI } from '../workflow-adapters.ts'
 
 const githubOutput = process.env.GITHUB_OUTPUT
@@ -180,7 +181,7 @@ if (evidencePrepared) {
       credentials
     })
     if (githubOutput) {
-      await appendFile(githubOutput, 'failure_evidence_ready=true\n')
+      await writeStepOutputs(githubOutput, { failure_evidence_ready: 'true' })
     }
   } catch (error) {
     errors.push(`Failure evidence verification failed: ${messageFrom(error)}`)

--- a/src/e2e/scripts/generate-health-value.ts
+++ b/src/e2e/scripts/generate-health-value.ts
@@ -1,5 +1,5 @@
-import { appendFile } from 'node:fs/promises'
 import { generateHealthValue, HEALTH_VALUE_ENV_NAME } from '../health-value.ts'
+import { writeStepOutputs } from '../step-output.ts'
 
 const githubOutput = process.env.GITHUB_OUTPUT
 
@@ -12,7 +12,7 @@ if (!value.endsWith('==')) {
   throw new Error('Generated health value must use 16-byte base64 padding')
 }
 
-await appendFile(
-  githubOutput,
-  `name=${HEALTH_VALUE_ENV_NAME}\nvalue=${value}\n`
-)
+await writeStepOutputs(githubOutput, {
+  name: HEALTH_VALUE_ENV_NAME,
+  value
+})

--- a/src/e2e/scripts/observe-divergent-force.ts
+++ b/src/e2e/scripts/observe-divergent-force.ts
@@ -1,6 +1,7 @@
-import { appendFile, readFile } from 'node:fs/promises'
+import { readFile } from 'node:fs/promises'
 import { createCleverController } from '../clever-client.ts'
 import { waitForNewHealthyDeployment } from '../deployment-observer.ts'
+import { writeStepOutputs } from '../step-output.ts'
 import {
   createFetchHealth,
   createRunCommand,
@@ -59,9 +60,8 @@ if (result.health.CC_DEPLOYMENT_ID === previousState.deploymentId) {
   )
 }
 
-await appendFile(
-  githubOutput,
-  `instance_id=${result.health.INSTANCE_ID ?? ''}\n` +
-    `deployment_id=${result.deployment.uuid ?? result.health.CC_DEPLOYMENT_ID ?? ''}\n` +
-    `commit_id=${result.health.CC_COMMIT_ID ?? ''}\n`
-)
+await writeStepOutputs(githubOutput, {
+  instance_id: result.health.INSTANCE_ID,
+  deployment_id: result.deployment.uuid ?? result.health.CC_DEPLOYMENT_ID,
+  commit_id: result.health.CC_COMMIT_ID
+})

--- a/src/e2e/scripts/observe-env-deployment.ts
+++ b/src/e2e/scripts/observe-env-deployment.ts
@@ -1,6 +1,6 @@
-import { appendFile } from 'node:fs/promises'
 import { createCleverController } from '../clever-client.ts'
 import { waitForHealthyDeployment } from '../deployment-observer.ts'
+import { writeStepOutputs } from '../step-output.ts'
 import {
   createFetchHealth,
   createRunCommand,
@@ -37,9 +37,8 @@ const health = await waitForHealthyDeployment({
   fetchHealth: createFetchHealth()
 })
 
-await appendFile(
-  githubOutput,
-  `instance_id=${health.INSTANCE_ID ?? ''}\n` +
-    `deployment_id=${health.CC_DEPLOYMENT_ID ?? ''}\n` +
-    `commit_id=${health.CC_COMMIT_ID ?? ''}\n`
-)
+await writeStepOutputs(githubOutput, {
+  instance_id: health.INSTANCE_ID,
+  deployment_id: health.CC_DEPLOYMENT_ID,
+  commit_id: health.CC_COMMIT_ID
+})

--- a/src/e2e/scripts/observe-healthy-deployment.ts
+++ b/src/e2e/scripts/observe-healthy-deployment.ts
@@ -1,6 +1,6 @@
-import { appendFile } from 'node:fs/promises'
 import { createCleverController } from '../clever-client.ts'
 import { waitForHealthyDeployment } from '../deployment-observer.ts'
+import { writeStepOutputs } from '../step-output.ts'
 import {
   createFetchHealth,
   createRunCommand,
@@ -34,9 +34,8 @@ const health = await waitForHealthyDeployment({
   fetchHealth: createFetchHealth()
 })
 
-await appendFile(
-  githubOutput,
-  `instance_id=${health.INSTANCE_ID ?? ''}\n` +
-    `deployment_id=${health.CC_DEPLOYMENT_ID ?? ''}\n` +
-    `commit_id=${health.CC_COMMIT_ID ?? ''}\n`
-)
+await writeStepOutputs(githubOutput, {
+  instance_id: health.INSTANCE_ID,
+  deployment_id: health.CC_DEPLOYMENT_ID,
+  commit_id: health.CC_COMMIT_ID
+})

--- a/src/e2e/scripts/observe-recovery-deployment.ts
+++ b/src/e2e/scripts/observe-recovery-deployment.ts
@@ -1,6 +1,6 @@
-import { appendFile } from 'node:fs/promises'
 import { createCleverController } from '../clever-client.ts'
 import { waitForHealthyDeployment } from '../deployment-observer.ts'
+import { writeStepOutputs } from '../step-output.ts'
 import {
   createFetchHealth,
   createRunCommand,
@@ -34,9 +34,8 @@ const health = await waitForHealthyDeployment({
   fetchHealth: createFetchHealth()
 })
 
-await appendFile(
-  githubOutput,
-  `instance_id=${health.INSTANCE_ID ?? ''}\n` +
-    `deployment_id=${health.CC_DEPLOYMENT_ID ?? ''}\n` +
-    `commit_id=${health.CC_COMMIT_ID ?? ''}\n`
-)
+await writeStepOutputs(githubOutput, {
+  instance_id: health.INSTANCE_ID,
+  deployment_id: health.CC_DEPLOYMENT_ID,
+  commit_id: health.CC_COMMIT_ID
+})

--- a/src/e2e/scripts/observe-same-commit-ignore.ts
+++ b/src/e2e/scripts/observe-same-commit-ignore.ts
@@ -1,9 +1,10 @@
-import { appendFile, readFile } from 'node:fs/promises'
+import { readFile } from 'node:fs/promises'
 import { createCleverController } from '../clever-client.ts'
 import {
   confirmNoNewDeploymentActivity,
   waitForHealthyDeployment
 } from '../deployment-observer.ts'
+import { writeStepOutputs } from '../step-output.ts'
 import {
   createFetchHealth,
   createRunCommand,
@@ -68,9 +69,8 @@ if (health.CC_COMMIT_ID !== previousState.commitId) {
   )
 }
 
-await appendFile(
-  githubOutput,
-  `instance_id=${health.INSTANCE_ID ?? ''}\n` +
-    `deployment_id=${health.CC_DEPLOYMENT_ID ?? ''}\n` +
-    `commit_id=${health.CC_COMMIT_ID ?? ''}\n`
-)
+await writeStepOutputs(githubOutput, {
+  instance_id: health.INSTANCE_ID,
+  deployment_id: health.CC_DEPLOYMENT_ID,
+  commit_id: health.CC_COMMIT_ID
+})

--- a/src/e2e/scripts/observe-same-commit-rebuild.ts
+++ b/src/e2e/scripts/observe-same-commit-rebuild.ts
@@ -1,10 +1,11 @@
-import { appendFile, readFile } from 'node:fs/promises'
+import { readFile } from 'node:fs/promises'
 import { createCleverController } from '../clever-client.ts'
 import {
   waitForHealthyDeployment,
   waitForNewSuccessfulDeploymentActivity
 } from '../deployment-observer.ts'
 import { FIXTURE_BUILD_MARKER } from '../fixture-app.ts'
+import { writeStepOutputs } from '../step-output.ts'
 import {
   createFetchHealth,
   createRunCommand,
@@ -86,9 +87,8 @@ if (!logContent.includes(FIXTURE_BUILD_MARKER)) {
   )
 }
 
-await appendFile(
-  githubOutput,
-  `instance_id=${health.INSTANCE_ID ?? ''}\n` +
-    `deployment_id=${health.CC_DEPLOYMENT_ID ?? ''}\n` +
-    `commit_id=${health.CC_COMMIT_ID ?? ''}\n`
-)
+await writeStepOutputs(githubOutput, {
+  instance_id: health.INSTANCE_ID,
+  deployment_id: health.CC_DEPLOYMENT_ID,
+  commit_id: health.CC_COMMIT_ID
+})

--- a/src/e2e/scripts/observe-same-commit-restart.ts
+++ b/src/e2e/scripts/observe-same-commit-restart.ts
@@ -1,10 +1,11 @@
-import { appendFile, readFile, writeFile } from 'node:fs/promises'
+import { readFile, writeFile } from 'node:fs/promises'
 import { createCleverController } from '../clever-client.ts'
 import {
   waitForHealthyDeployment,
   waitForNewSuccessfulDeploymentActivity
 } from '../deployment-observer.ts'
 import { FIXTURE_BUILD_MARKER } from '../fixture-app.ts'
+import { writeStepOutputs } from '../step-output.ts'
 import {
   createFetchHealth,
   createRunCommand,
@@ -97,9 +98,8 @@ await writeFile(
   'utf8'
 )
 
-await appendFile(
-  githubOutput,
-  `instance_id=${health.INSTANCE_ID ?? ''}\n` +
-    `deployment_id=${health.CC_DEPLOYMENT_ID ?? ''}\n` +
-    `commit_id=${health.CC_COMMIT_ID ?? ''}\n`
-)
+await writeStepOutputs(githubOutput, {
+  instance_id: health.INSTANCE_ID,
+  deployment_id: health.CC_DEPLOYMENT_ID,
+  commit_id: health.CC_COMMIT_ID
+})

--- a/src/e2e/scripts/observe-timeout-cancellation.ts
+++ b/src/e2e/scripts/observe-timeout-cancellation.ts
@@ -1,6 +1,6 @@
-import { appendFile } from 'node:fs/promises'
 import { createCleverController } from '../clever-client.ts'
 import { cancelTimedOutDeploymentPreservesLiveApp } from '../deployment-observer.ts'
+import { writeStepOutputs } from '../step-output.ts'
 import {
   createFetchHealth,
   createRunCommand,
@@ -67,10 +67,9 @@ if (result.outcome === 'completed') {
   console.log(`Timed-out deployment settled as ${result.outcome}`)
 }
 
-await appendFile(
-  githubOutput,
-  `outcome=${result.outcome}\n` +
-    `instance_id=${result.health.INSTANCE_ID ?? ''}\n` +
-    `deployment_id=${result.deployment.uuid ?? ''}\n` +
-    `commit_id=${result.deployment.commit ?? expectedCancelledCommitID}\n`
-)
+await writeStepOutputs(githubOutput, {
+  outcome: result.outcome,
+  instance_id: result.health.INSTANCE_ID,
+  deployment_id: result.deployment.uuid,
+  commit_id: result.deployment.commit ?? expectedCancelledCommitID
+})

--- a/src/e2e/scripts/pin-preview-action.ts
+++ b/src/e2e/scripts/pin-preview-action.ts
@@ -1,9 +1,10 @@
-import { appendFile, readFile, writeFile } from 'node:fs/promises'
+import { readFile, writeFile } from 'node:fs/promises'
 import { pinActionMetadata } from '../candidate-image.ts'
 import {
   createImagetoolsInspect,
   inspectCandidateImage
 } from '../image-inspection.ts'
+import { writeStepOutputs } from '../step-output.ts'
 
 const image = process.env.CANDIDATE_IMAGE
 const expectedRevision = process.env.EXPECTED_REVISION
@@ -39,9 +40,8 @@ const pinnedMetadata = pinActionMetadata({
 })
 
 await writeFile(outputActionPath, pinnedMetadata)
-await appendFile(
-  githubOutput,
-  `digest=${candidate.digest}\n` +
-    `image=${candidate.image}\n` +
-    `action_metadata_path=${outputActionPath}\n`
-)
+await writeStepOutputs(githubOutput, {
+  digest: candidate.digest,
+  image: candidate.image,
+  action_metadata_path: outputActionPath
+})

--- a/src/e2e/scripts/probe-existing-image.ts
+++ b/src/e2e/scripts/probe-existing-image.ts
@@ -1,8 +1,8 @@
-import { appendFile } from 'node:fs/promises'
 import {
   createImagetoolsInspect,
   probeCandidateImage
 } from '../image-inspection.ts'
+import { writeStepOutputs } from '../step-output.ts'
 
 const image = process.env.CANDIDATE_IMAGE
 const expectedRevision = process.env.EXPECTED_REVISION
@@ -25,11 +25,12 @@ if (result.missing) {
   console.log(
     `::warning::Candidate image ${image} not found, building it. Registry said: ${registryDetail}`
   )
-  await appendFile(githubOutput, 'missing=true\n')
+  await writeStepOutputs(githubOutput, { missing: 'true' })
   process.exit(0)
 }
 
-await appendFile(
-  githubOutput,
-  `missing=false\n` + `digest=${result.digest}\n` + `image=${result.image}\n`
-)
+await writeStepOutputs(githubOutput, {
+  missing: 'false',
+  digest: result.digest,
+  image: result.image
+})

--- a/src/e2e/scripts/recheck-candidate-staleness.ts
+++ b/src/e2e/scripts/recheck-candidate-staleness.ts
@@ -5,6 +5,7 @@ import {
   violatesAutomaticCandidatePolicy
 } from '../candidate-policy.ts'
 import { createGitHubClient } from '../github-api.ts'
+import { writeStepOutputs } from '../step-output.ts'
 
 const headSha = process.env.HEAD_SHA
 const prNumberInput = process.env.PR_NUMBER
@@ -40,7 +41,7 @@ if (
   (caller === 'automatic' && violatesAutomaticCandidatePolicy(pr))
 ) {
   if (caller === 'automatic') {
-    await appendFile(githubOutput, 'proceed=false\n')
+    await writeStepOutputs(githubOutput, { proceed: 'false' })
     await appendFile(
       summaryPath,
       buildSupersededSummary(
@@ -54,5 +55,5 @@ if (
     process.exit(1)
   }
 } else {
-  await appendFile(githubOutput, 'proceed=true\n')
+  await writeStepOutputs(githubOutput, { proceed: 'true' })
 }

--- a/src/e2e/scripts/recheck-release-candidate-freshness.ts
+++ b/src/e2e/scripts/recheck-release-candidate-freshness.ts
@@ -4,6 +4,7 @@ import {
   isCurrentAutomaticCandidate
 } from '../candidate-policy.ts'
 import { createGitHubClient } from '../github-api.ts'
+import { writeStepOutputs } from '../step-output.ts'
 
 const headSha = process.env.HEAD_SHA
 const prNumber = Number(process.env.PR_NUMBER)
@@ -33,7 +34,7 @@ const github = createGitHubClient({ token, repository: thisRepo })
 const pr = await github.getPullRequest(prNumber)
 
 if (!isCurrentAutomaticCandidate({ pr, thisRepo, defaultBranch, headSha })) {
-  await appendFile(githubOutput, 'proceed=false\n')
+  await writeStepOutputs(githubOutput, { proceed: 'false' })
   await appendFile(
     stepSummary,
     buildSupersededSummary(
@@ -43,4 +44,4 @@ if (!isCurrentAutomaticCandidate({ pr, thisRepo, defaultBranch, headSha })) {
   process.exit(0)
 }
 
-await appendFile(githubOutput, 'proceed=true\n')
+await writeStepOutputs(githubOutput, { proceed: 'true' })

--- a/src/e2e/scripts/resolve-manual-candidate.ts
+++ b/src/e2e/scripts/resolve-manual-candidate.ts
@@ -1,6 +1,6 @@
-import { appendFile } from 'node:fs/promises'
 import { filterManualCandidatePulls } from '../candidate-policy.ts'
 import { createGitHubClient } from '../github-api.ts'
+import { writeStepOutputs } from '../step-output.ts'
 
 const headSha = process.env.HEAD_SHA
 const runRef = process.env.RUN_REF
@@ -38,9 +38,8 @@ if (matches.length !== 1 || match === undefined) {
   process.exit(1)
 }
 
-await appendFile(
-  githubOutput,
-  `head_sha=${headSha}\n` +
-    `pr_number=${String(match.number)}\n` +
-    `candidate_source_repository=${thisRepo}\n`
-)
+await writeStepOutputs(githubOutput, {
+  head_sha: headSha,
+  pr_number: String(match.number),
+  candidate_source_repository: thisRepo
+})

--- a/src/e2e/scripts/verify-image.ts
+++ b/src/e2e/scripts/verify-image.ts
@@ -1,9 +1,9 @@
-import { appendFile } from 'node:fs/promises'
 import {
   createImagetoolsInspect,
   inspectionFailure,
   probeCandidateImage
 } from '../image-inspection.ts'
+import { writeStepOutputs } from '../step-output.ts'
 
 const image = process.env.CANDIDATE_IMAGE
 const expectedRevision = process.env.EXPECTED_REVISION
@@ -25,7 +25,7 @@ if (result.missing) {
   throw inspectionFailure(image, result.registryStderr)
 }
 
-await appendFile(
-  githubOutput,
-  `digest=${result.digest}\n` + `image=${result.image}\n`
-)
+await writeStepOutputs(githubOutput, {
+  digest: result.digest,
+  image: result.image
+})

--- a/src/e2e/step-output.test.ts
+++ b/src/e2e/step-output.test.ts
@@ -1,0 +1,72 @@
+import { mkdtemp, readFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { expect, test } from 'vitest'
+import { formatStepOutputs, writeStepOutputs } from './step-output.ts'
+
+test('formats a single output as a delimited block', () => {
+  expect(formatStepOutputs({ commit: 'abc123' }, () => 'DELIM')).toBe(
+    'commit<<DELIM\nabc123\nDELIM\n'
+  )
+})
+
+test('formats several outputs in order', () => {
+  expect(formatStepOutputs({ a: '1', b: '2' }, () => 'DELIM')).toBe(
+    'a<<DELIM\n1\nDELIM\nb<<DELIM\n2\nDELIM\n'
+  )
+})
+
+test('treats null and undefined as an empty value', () => {
+  expect(formatStepOutputs({ instance_id: null }, () => 'DELIM')).toBe(
+    'instance_id<<DELIM\n\nDELIM\n'
+  )
+})
+
+test('contains a value that spans lines without forging a second output', () => {
+  const result = formatStepOutputs(
+    { instance_id: 'real\nforged=true' },
+    () => 'DELIM'
+  )
+
+  expect(result).toContain('real\nforged=true')
+
+  const openingLines = result
+    .split('\n')
+    .filter(line => line === 'instance_id<<DELIM')
+
+  expect(openingLines).toHaveLength(1)
+})
+
+test('rejects a value that contains the delimiter', () => {
+  expect(() =>
+    formatStepOutputs({ a: 'xDELIMx' }, () => 'DELIM')
+  ).toThrow('collides with its own delimiter')
+})
+
+test('rejects an unsafe output name', () => {
+  expect(() =>
+    formatStepOutputs({ 'a=b': 'x' }, () => 'DELIM')
+  ).toThrow('Unsafe step output name')
+})
+
+test('the default delimiter differs between calls', () => {
+  const first = formatStepOutputs({ a: 'x' })
+  const second = formatStepOutputs({ a: 'x' })
+
+  expect(first).not.toBe(second)
+})
+
+test('writeStepOutputs appends rather than truncates', async () => {
+  const directory = await mkdtemp(
+    path.join(os.tmpdir(), 'actions-clever-cloud-step-output-')
+  )
+  const githubOutputPath = path.join(directory, 'github-output')
+
+  await writeStepOutputs(githubOutputPath, { a: '1' })
+  await writeStepOutputs(githubOutputPath, { b: '2' })
+
+  const contents = await readFile(githubOutputPath, 'utf-8')
+
+  expect(contents).toContain('a<<')
+  expect(contents).toContain('b<<')
+})

--- a/src/e2e/step-output.test.ts
+++ b/src/e2e/step-output.test.ts
@@ -38,15 +38,15 @@ test('contains a value that spans lines without forging a second output', () => 
 })
 
 test('rejects a value that contains the delimiter', () => {
-  expect(() =>
-    formatStepOutputs({ a: 'xDELIMx' }, () => 'DELIM')
-  ).toThrow('collides with its own delimiter')
+  expect(() => formatStepOutputs({ a: 'xDELIMx' }, () => 'DELIM')).toThrow(
+    'collides with its own delimiter'
+  )
 })
 
 test('rejects an unsafe output name', () => {
-  expect(() =>
-    formatStepOutputs({ 'a=b': 'x' }, () => 'DELIM')
-  ).toThrow('Unsafe step output name')
+  expect(() => formatStepOutputs({ 'a=b': 'x' }, () => 'DELIM')).toThrow(
+    'Unsafe step output name'
+  )
 })
 
 test('the default delimiter differs between calls', () => {

--- a/src/e2e/step-output.ts
+++ b/src/e2e/step-output.ts
@@ -1,0 +1,39 @@
+import { randomUUID } from 'node:crypto'
+import { appendFile } from 'node:fs/promises'
+
+type StepOutputs = Record<string, string | null | undefined>
+
+export function formatStepOutputs(
+  outputs: StepOutputs,
+  createDelimiter: () => string = defaultDelimiter
+): string {
+  let formatted = ''
+
+  for (const [name, value] of Object.entries(outputs)) {
+    if (!/^[A-Za-z_][A-Za-z0-9_-]*$/.test(name)) {
+      throw new Error(`Unsafe step output name: ${name}`)
+    }
+
+    const text = value ?? ''
+    const delimiter = createDelimiter()
+
+    if (text.includes(delimiter)) {
+      throw new Error(`Step output ${name} collides with its own delimiter`)
+    }
+
+    formatted += `${name}<<${delimiter}\n${text}\n${delimiter}\n`
+  }
+
+  return formatted
+}
+
+export async function writeStepOutputs(
+  githubOutputPath: string,
+  outputs: StepOutputs
+): Promise<void> {
+  await appendFile(githubOutputPath, formatStepOutputs(outputs))
+}
+
+function defaultDelimiter(): string {
+  return `__E2E_OUTPUT_${randomUUID()}__`
+}

--- a/src/e2eWorkflowInvariants.test.ts
+++ b/src/e2eWorkflowInvariants.test.ts
@@ -311,6 +311,17 @@ describe('runtime module resolution', () => {
       }
     }
   })
+
+  test('every script writes step outputs through the shared safe writer', () => {
+    for (const scriptName of readdirSync(scriptsDir)) {
+      const source = scriptSourceOf(scriptName)
+      if (!source.includes('GITHUB_OUTPUT')) {
+        continue
+      }
+      expect(source, scriptName).not.toContain('appendFile(githubOutput')
+      expect(source, scriptName).toContain('writeStepOutputs(')
+    }
+  })
 })
 
 describe('pr-preview', () => {
@@ -772,9 +783,9 @@ describe('e2e-reusable', () => {
     expect(source).toContain('prepareFailureEvidence')
     const verifyIndex = source.indexOf('await verifyPreparedFailureEvidence(')
     expect(verifyIndex).toBeGreaterThan(-1)
-    expect(source.indexOf('failure_evidence_ready=true')).toBeGreaterThan(
-      verifyIndex
-    )
+    expect(
+      source.indexOf("failure_evidence_ready: 'true'")
+    ).toBeGreaterThan(verifyIndex)
     const evidenceSource = readFileSync(
       join(e2eModulesDir, 'evidence.ts'),
       'utf8'


### PR DESCRIPTION
Every e2e step output was built by string concatenation, including values parsed out of the deployed application's HTTP response. A value carrying a newline turns into extra key/value lines, which is why GitHub documents a delimiter syntax for that file.

Nothing here was exploitable. The values are uuids and commit shas produced by our own fixture, running in our own app. But this repo's rule is to keep untrusted values out of workflow plumbing, and the output direction was the one sink where we had not applied it.

One helper now encodes every output with a per-call random delimiter, the 25 scripts route through it, and a static test stops a new script regressing to raw concatenation. Test infrastructure only; the shipped action is unchanged.
