### PR TITLE
chore: report failed e2e deployments instead of polling to the deadline

### DIFF
--- a/src/e2e/deployment-observer.test.ts
+++ b/src/e2e/deployment-observer.test.ts
@@ -1299,3 +1299,154 @@ test('times out when a healthy deploy never reaches a completed activity', async
     })
   ).rejects.toThrow('Timed out while waiting for a healthy deployment')
 })
+
+test('waitForHealthyDeployment fails fast on a terminal failed state', async () => {
+  await expect(
+    waitForHealthyDeployment({
+      appId: 'app_facade42-cafe-babe-cafe-deadf00dbaad',
+      healthURL: 'https://fixture.example.com/health',
+      expectedScenario: 'healthy',
+      expectedCommitID: 'commit-123',
+      listActivity: async () => [
+        {
+          action: 'DEPLOY',
+          state: 'FAIL',
+          uuid: 'deployment-123',
+          commit: 'commit-123'
+        }
+      ],
+      fetchHealth: async () => {
+        throw new Error('health should not be fetched for a failed deploy')
+      },
+      sleep: async () => {},
+      settleTimeoutMs: 600_000,
+      pollIntervalMs: 1
+    })
+  ).rejects.toThrow('reached a failed state: FAIL')
+})
+
+test('waitForHealthyDeployment keeps waiting when the same commit also has a successful row', async () => {
+  const health = await waitForHealthyDeployment({
+    appId: 'app_facade42-cafe-babe-cafe-deadf00dbaad',
+    healthURL: 'https://fixture.example.com/health',
+    expectedScenario: 'healthy',
+    expectedCommitID: 'commit-123',
+    expectedDeploymentID: 'deployment-new',
+    listActivity: async () => [
+      {
+        action: 'DEPLOY',
+        state: 'FAIL',
+        uuid: 'deployment-old',
+        commit: 'commit-123'
+      },
+      {
+        action: 'DEPLOY',
+        state: 'SUCCESS',
+        uuid: 'deployment-new',
+        commit: 'commit-123'
+      }
+    ],
+    fetchHealth: async () => ({
+      status: 200,
+      json: async () => ({
+        scenario: 'healthy',
+        healthValue: null,
+        INSTANCE_ID: 'instance-1',
+        INSTANCE_TYPE: 'production',
+        CC_DEPLOYMENT_ID: 'deployment-new',
+        CC_COMMIT_ID: 'commit-123'
+      })
+    }),
+    sleep: async () => {},
+    settleTimeoutMs: 600_000,
+    pollIntervalMs: 1
+  })
+
+  expect(health.CC_DEPLOYMENT_ID).toBe('deployment-new')
+})
+
+test('keeps waiting when a failed row is accompanied by an in-progress retry for the same commit', async () => {
+  let activityCalls = 0
+  const health = await waitForHealthyDeployment({
+    appId: 'app_facade42-cafe-babe-cafe-deadf00dbaad',
+    healthURL: 'https://fixture.example.com/health',
+    expectedScenario: 'healthy',
+    expectedCommitID: 'commit-123',
+    expectedDeploymentID: 'deployment-new',
+    listActivity: async () => {
+      activityCalls += 1
+      return [
+        {
+          action: 'DEPLOY',
+          state: 'FAIL',
+          uuid: 'deployment-old',
+          commit: 'commit-123'
+        },
+        {
+          action: 'DEPLOY',
+          state: activityCalls === 1 ? 'WIP' : 'SUCCESS',
+          uuid: 'deployment-new',
+          commit: 'commit-123'
+        }
+      ]
+    },
+    fetchHealth: async () => ({
+      status: 200,
+      json: async () => ({
+        scenario: 'healthy',
+        healthValue: null,
+        INSTANCE_ID: 'instance-1',
+        INSTANCE_TYPE: 'production',
+        CC_DEPLOYMENT_ID: 'deployment-new',
+        CC_COMMIT_ID: 'commit-123'
+      })
+    }),
+    sleep: async () => {},
+    settleTimeoutMs: 10_000,
+    pollIntervalMs: 1
+  })
+
+  expect(health.CC_DEPLOYMENT_ID).toBe('deployment-new')
+})
+
+test('waitForNewSuccessfulDeploymentActivity fails fast on a terminal failed state', async () => {
+  await expect(
+    waitForNewSuccessfulDeploymentActivity({
+      appId: 'app_facade42-cafe-babe-cafe-deadf00dbaad',
+      expectedCommitID: 'commit-123',
+      previousActivity: [],
+      listActivity: async () => [
+        {
+          action: 'DEPLOY',
+          state: 'FAILED',
+          uuid: 'deployment-123',
+          commit: 'commit-123'
+        }
+      ],
+      sleep: async () => {},
+      settleTimeoutMs: 600_000,
+      pollIntervalMs: 1
+    })
+  ).rejects.toThrow('reached a failed state: FAILED')
+})
+
+test('waitForNewFailedDeploymentActivity is unaffected by the fail-fast check', async () => {
+  const deployment = await waitForNewFailedDeploymentActivity({
+    appId: 'app_facade42-cafe-babe-cafe-deadf00dbaad',
+    expectedCommitID: 'commit-123',
+    previousActivity: [],
+    listActivity: async () => [
+      {
+        action: 'DEPLOY',
+        state: 'FAILED',
+        uuid: 'deployment-123',
+        commit: 'commit-123'
+      }
+    ],
+    sleep: async () => {},
+    settleTimeoutMs: 600_000,
+    pollIntervalMs: 1
+  })
+
+  expect(deployment.uuid).toBe('deployment-123')
+})

--- a/src/e2e/deployment-observer.ts
+++ b/src/e2e/deployment-observer.ts
@@ -356,6 +356,18 @@ async function waitForNewDeploymentActivity({
         !previousSnapshot.has(serializeActivity(entry))
     )
 
+    if (stateLabel === 'successful') {
+      const failedDeployment = findTerminallyFailedDeployment(
+        activity,
+        expectedCommitID
+      )
+      if (failedDeployment) {
+        throw new Error(
+          `Deployment ${failedDeployment.uuid ?? '(unknown)'} of ${expectedCommitID} on ${appId} reached a failed state: ${failedDeployment.state ?? '(missing)'}`
+        )
+      }
+    }
+
     if (deployment?.uuid) {
       return deployment
     }
@@ -440,6 +452,16 @@ export async function waitForHealthyDeployment({
         entry.commit === expectedCommitID &&
         (!expectedDeploymentID || entry.uuid === expectedDeploymentID)
     )
+
+    const failedDeployment = findTerminallyFailedDeployment(
+      activity,
+      expectedCommitID
+    )
+    if (failedDeployment) {
+      throw new Error(
+        `Deployment ${failedDeployment.uuid ?? '(unknown)'} of ${expectedCommitID} on ${appId} reached a failed state: ${failedDeployment.state ?? '(missing)'}`
+      )
+    }
 
     if (deployment && isSuccessfulDeploymentState(deployment.state)) {
       try {
@@ -705,6 +727,31 @@ function isFailedDeploymentState(state: string | undefined): boolean {
   return Boolean(
     state && FAILED_STATES.has(state) && !IN_PROGRESS_STATES.has(state)
   )
+}
+
+function findTerminallyFailedDeployment(
+  activity: DeploymentActivity[],
+  expectedCommitID: string
+): DeploymentActivity | undefined {
+  const deployments = activity.filter(
+    entry => entry.action === 'DEPLOY' && entry.commit === expectedCommitID
+  )
+
+  if (deployments.length === 0) {
+    return undefined
+  }
+
+  if (
+    deployments.some(
+      entry =>
+        isSuccessfulDeploymentState(entry.state) ||
+        isInProgressState(entry.state)
+    )
+  ) {
+    return undefined
+  }
+
+  return deployments.find(entry => isFailedDeploymentState(entry.state))
 }
 
 function serializeActivity(activity: DeploymentActivity): string {


### PR DESCRIPTION
The observer's two wait loops only advanced on a success state. A deployment that failed was treated like one still building: keep polling until the five-minute budget runs out, then report `Timed out while waiting for a healthy deployment`. That points whoever is debugging a live run at a slow platform or a tight budget, when Clever had already reported the failure minutes earlier.

Both loops now stop as soon as a commit has definitively failed, and name the state, commit and deployment id.

Scope, after tracing every caller: narrower than it looks. Most observers wait on a commit that has already succeeded, because the same-commit policies reuse one commit and the failure scenarios check that the *prior* good deployment survived. The guard correctly stays silent for those. It is live where a deployment can still fail while the observer watches: the forced divergent deploy, and any scenario where the action hits its own timeout, returns success as documented, and Clever fails the build afterwards.

The check stays conservative. It fails fast only when no row for that commit is successful or still in progress, because the same commit legitimately gets several deploy rows. Aborting a healthy scenario would be worse than the bug being fixed, so two tests pin that behaviour. One covers a commit carrying both a failed and a successful row, the other a failed row alongside an in-progress retry. Delete either arm of the guard and a test fails.
