### PR TITLE
chore: bound how long a stuck e2e run can hold a live app

### DIFF
--- a/.github/workflows/e2e-manual.yml
+++ b/.github/workflows/e2e-manual.yml
@@ -14,7 +14,7 @@ jobs:
   resolve:
     name: Resolve internal pull request
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 5
     permissions:
       contents: read
       pull-requests: read
@@ -41,7 +41,7 @@ jobs:
     name: Resolve verified candidate image
     needs: resolve
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 10
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/e2e-manual.yml
+++ b/.github/workflows/e2e-manual.yml
@@ -14,6 +14,7 @@ jobs:
   resolve:
     name: Resolve internal pull request
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: read
@@ -40,6 +41,7 @@ jobs:
     name: Resolve verified candidate image
     needs: resolve
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: read

--- a/.github/workflows/e2e-release-please.yml
+++ b/.github/workflows/e2e-release-please.yml
@@ -28,7 +28,7 @@ jobs:
   resolve:
     name: Resolve eligible Release Please candidate
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 5
     permissions:
       contents: read
       pull-requests: read
@@ -56,7 +56,7 @@ jobs:
     name: Reject stale automatic candidates before image work
     needs: resolve
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 5
     permissions:
       contents: read
       pull-requests: read
@@ -82,7 +82,7 @@ jobs:
     if: needs.current-state.outputs.proceed == 'true'
     needs: [resolve, current-state]
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 20
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/e2e-release-please.yml
+++ b/.github/workflows/e2e-release-please.yml
@@ -28,6 +28,7 @@ jobs:
   resolve:
     name: Resolve eligible Release Please candidate
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: read
@@ -55,6 +56,7 @@ jobs:
     name: Reject stale automatic candidates before image work
     needs: resolve
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: read
@@ -80,6 +82,7 @@ jobs:
     if: needs.current-state.outputs.proceed == 'true'
     needs: [resolve, current-state]
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -35,7 +35,7 @@ jobs:
   create-and-delete:
     name: Create and delete app
     runs-on: ubuntu-latest
-    timeout-minutes: 150
+    timeout-minutes: 40
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -35,6 +35,7 @@ jobs:
   create-and-delete:
     name: Create and delete app
     runs-on: ubuntu-latest
+    timeout-minutes: 150
     permissions:
       contents: read
       pull-requests: read

--- a/src/e2e/git-fixture.ts
+++ b/src/e2e/git-fixture.ts
@@ -12,6 +12,8 @@ import {
 
 const execFileAsync = promisify(execFile)
 
+const GIT_COMMAND_TIMEOUT_MS = 60_000
+
 const FIXTURE_GITIGNORE_LINES = [
   '.candidate-source/',
   '.candidate-action/',
@@ -204,7 +206,9 @@ async function writeFixtureVersion(workspaceDir: string, label: string): Promise
 async function runGit(cwd: string, args: string[]): Promise<string> {
   const { stdout } = await execFileAsync('git', args, {
     cwd,
-    encoding: 'utf8'
+    encoding: 'utf8',
+    timeout: GIT_COMMAND_TIMEOUT_MS,
+    maxBuffer: 1024 * 1024 * 10
   })
   return stdout.trim()
 }

--- a/src/e2e/github-api.test.ts
+++ b/src/e2e/github-api.test.ts
@@ -1,6 +1,14 @@
 import { http, HttpResponse } from 'msw'
 import { setupServer } from 'msw/node'
-import { afterAll, afterEach, beforeAll, describe, expect, test } from 'vitest'
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  test,
+  vi
+} from 'vitest'
 import { createGitHubClient } from './github-api.ts'
 
 type RecordedRequest = {
@@ -159,5 +167,23 @@ describe('createGitHubClient', () => {
     await expect(client.getPullRequest(404)).rejects.toThrow(
       'GitHub API GET /repos/47ng/actions-clever-cloud/pulls/404 failed with status 404'
     )
+  })
+
+  test('aborts a request that hangs past the request timeout', async () => {
+    vi.useFakeTimers()
+    try {
+      server.use(
+        http.get(
+          'https://api.github.com/repos/47ng/actions-clever-cloud',
+          () => new Promise(() => {})
+        )
+      )
+
+      const pending = expect(client.getRepository()).rejects.toThrow(/aborted/i)
+      await vi.advanceTimersByTimeAsync(120_000)
+      await pending
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/src/e2e/github-api.ts
+++ b/src/e2e/github-api.ts
@@ -25,6 +25,8 @@ type GitHubClientOptions = {
   repository: string
 }
 
+const REQUEST_TIMEOUT_MS = 30_000
+
 export function createGitHubClient({
   token,
   repository
@@ -34,17 +36,29 @@ export function createGitHubClient({
     path: string,
     body?: unknown
   ): Promise<unknown> {
-    const response = await fetch(`https://api.github.com${path}`, {
-      method,
-      headers: {
-        authorization: `Bearer ${token}`,
-        accept: 'application/vnd.github+json',
-        'x-github-api-version': '2022-11-28',
-        'user-agent': 'actions-clever-cloud-e2e',
-        ...(body === undefined ? {} : { 'content-type': 'application/json' })
-      },
-      ...(body === undefined ? {} : { body: JSON.stringify(body) })
-    })
+    const requestController = new AbortController()
+    const timeoutId = setTimeout(
+      () => requestController.abort(),
+      REQUEST_TIMEOUT_MS
+    )
+
+    let response: Response
+    try {
+      response = await fetch(`https://api.github.com${path}`, {
+        method,
+        signal: requestController.signal,
+        headers: {
+          authorization: `Bearer ${token}`,
+          accept: 'application/vnd.github+json',
+          'x-github-api-version': '2022-11-28',
+          'user-agent': 'actions-clever-cloud-e2e',
+          ...(body === undefined ? {} : { 'content-type': 'application/json' })
+        },
+        ...(body === undefined ? {} : { body: JSON.stringify(body) })
+      })
+    } finally {
+      clearTimeout(timeoutId)
+    }
 
     if (!response.ok) {
       throw new Error(

--- a/src/e2eWorkflowInvariants.test.ts
+++ b/src/e2eWorkflowInvariants.test.ts
@@ -26,6 +26,7 @@ type Job = {
   environment?: string | { name?: string }
   steps?: Step[]
   with?: Record<string, unknown>
+  'timeout-minutes'?: number
 }
 
 type Trigger = {
@@ -292,6 +293,24 @@ describe('shared workflow policies', () => {
           step => step.uses?.startsWith('actions/cache@') ?? false
         )
       ).toEqual([])
+    }
+  )
+
+  test.each(e2eWorkflows)(
+    '%s bounds every runner job with a timeout',
+    (file, workflow) => {
+      for (const [jobId, job] of Object.entries(workflow.jobs)) {
+        if (job.uses !== undefined) {
+          // GitHub rejects timeout-minutes on a reusable workflow call; the
+          // called workflow's own job carries the budget.
+          expect(job['timeout-minutes']).toBeUndefined()
+          continue
+        }
+        expect(job['timeout-minutes'], `${file} ${jobId}`).toBeGreaterThan(0)
+        expect(job['timeout-minutes'], `${file} ${jobId}`).toBeLessThanOrEqual(
+          240
+        )
+      }
     }
   )
 })

--- a/src/e2eWorkflowInvariants.test.ts
+++ b/src/e2eWorkflowInvariants.test.ts
@@ -313,7 +313,7 @@ describe('shared workflow policies', () => {
         }
         expect(job['timeout-minutes'], `${file} ${jobId}`).toBeGreaterThan(0)
         expect(job['timeout-minutes'], `${file} ${jobId}`).toBeLessThanOrEqual(
-          240
+          40
         )
       }
     }

--- a/src/e2eWorkflowInvariants.test.ts
+++ b/src/e2eWorkflowInvariants.test.ts
@@ -72,6 +72,11 @@ const e2eReusable = workflowOf('e2e-reusable.yml')
 
 const e2eWorkflows = allWorkflows.filter(([name]) => name.startsWith('e2e-'))
 
+test('the workflow collections are non-empty', () => {
+  expect(allWorkflows.length).toBeGreaterThan(0)
+  expect(e2eWorkflows.length).toBe(3)
+})
+
 const extractedWorkflows: Array<[string, Workflow]> = [
   ['e2e-manual.yml', e2eManual],
   ['e2e-release-please.yml', e2eAutomatic],


### PR DESCRIPTION
No job in any e2e workflow declared `timeout-minutes`, so GitHub's six-hour default was the only backstop. A stuck run holds three things for that window: a live Clever Cloud app that bills, the per-PR concurrency group (declared `cancel-in-progress: false`, so the next release candidate queues behind it), and a runner holding the Clever credentials.

Two code paths had no deadline either, so a hang there ran the full six hours. The GitHub API client called `fetch` with no abort signal, and the fixture git driver called `execFile` with no timeout.

The suite job now caps at 150 minutes, the smaller caller jobs at 10 to 60, and both unbounded paths get deadlines matching the pattern already used for Clever calls. A static invariant keeps the timeouts from disappearing, and exempts the two reusable-workflow callers, which GitHub forbids from declaring one.

About the 150: the qualifying live run took 7.8 minutes for the suite job. The per-step ceilings sum to 221 minutes, but reaching that needs every deploy to hang for its full budget, which is the case the cap exists to bound. Teardown is guarded `if: always()`, which still runs when a job is cancelled by timeout, so hitting the cap deletes the app rather than orphaning it.
