### PR TITLE
chore: cover the e2e scenario pass and fail rules locally

### DIFF
--- a/src/e2e/scenario-assertions.test.ts
+++ b/src/e2e/scenario-assertions.test.ts
@@ -1,0 +1,500 @@
+import { expect, test } from 'vitest'
+import type { FixtureHealth } from './fixture-app.ts'
+import {
+  assertBuildFailurePreservedProduction,
+  assertDivergentRejectionPreservedProduction,
+  assertForcedDeploymentReplacedProduction,
+  assertSameCommitIgnorePreservedProduction,
+  assertSameCommitRebuildChangedProduction,
+  assertSameCommitRestartChangedProduction,
+  assertStartupFailurePreservedProduction,
+  assertTimeoutOutcome,
+  parseBaselineState,
+  type BaselineState
+} from './scenario-assertions.ts'
+
+function health(overrides: Partial<FixtureHealth> = {}): FixtureHealth {
+  return {
+    scenario: 'healthy',
+    healthValue: null,
+    INSTANCE_ID: 'instance-1',
+    INSTANCE_TYPE: 'production',
+    CC_DEPLOYMENT_ID: 'deployment-1',
+    CC_COMMIT_ID: 'commit-1',
+    ...overrides
+  }
+}
+
+function baseline(overrides: Partial<BaselineState> = {}): BaselineState {
+  return {
+    activity: [],
+    instanceId: 'instance-1',
+    deploymentId: 'deployment-1',
+    commitId: 'commit-1',
+    ...overrides
+  }
+}
+
+test('same-commit ignore accepts unchanged production identifiers', () => {
+  expect(() =>
+    assertSameCommitIgnorePreservedProduction({
+      health: health(),
+      baseline: baseline()
+    })
+  ).not.toThrow()
+})
+
+test('same-commit ignore rejects a changed instance ID', () => {
+  expect(() =>
+    assertSameCommitIgnorePreservedProduction({
+      health: health({ INSTANCE_ID: 'instance-2' }),
+      baseline: baseline()
+    })
+  ).toThrow('Expected sameCommitPolicy: ignore to keep the same instance ID')
+})
+
+test('same-commit ignore rejects a changed deployment ID', () => {
+  expect(() =>
+    assertSameCommitIgnorePreservedProduction({
+      health: health({ CC_DEPLOYMENT_ID: 'deployment-2' }),
+      baseline: baseline()
+    })
+  ).toThrow('Expected sameCommitPolicy: ignore to keep the same deployment ID')
+})
+
+test('same-commit ignore rejects a changed commit ID', () => {
+  expect(() =>
+    assertSameCommitIgnorePreservedProduction({
+      health: health({ CC_COMMIT_ID: 'commit-2' }),
+      baseline: baseline()
+    })
+  ).toThrow('Expected sameCommitPolicy: ignore to keep the same commit ID')
+})
+
+test('same-commit restart accepts changed production identifiers with no cache marker', () => {
+  expect(() =>
+    assertSameCommitRestartChangedProduction({
+      health: health({
+        INSTANCE_ID: 'instance-2',
+        CC_DEPLOYMENT_ID: 'deployment-2'
+      }),
+      baseline: baseline(),
+      logContent: 'no markers here'
+    })
+  ).not.toThrow()
+})
+
+test('same-commit restart rejects a missing instance ID', () => {
+  expect(() =>
+    assertSameCommitRestartChangedProduction({
+      health: health({ INSTANCE_ID: null }),
+      baseline: baseline(),
+      logContent: ''
+    })
+  ).toThrow('Expected sameCommitPolicy: restart to report a new instance ID')
+})
+
+test('same-commit restart rejects an unchanged instance ID', () => {
+  expect(() =>
+    assertSameCommitRestartChangedProduction({
+      health: health({ CC_DEPLOYMENT_ID: 'deployment-2' }),
+      baseline: baseline(),
+      logContent: ''
+    })
+  ).toThrow('Expected sameCommitPolicy: restart to change the instance ID')
+})
+
+test('same-commit restart rejects an unchanged deployment ID', () => {
+  expect(() =>
+    assertSameCommitRestartChangedProduction({
+      health: health({ INSTANCE_ID: 'instance-2' }),
+      baseline: baseline(),
+      logContent: ''
+    })
+  ).toThrow('Expected sameCommitPolicy: restart to change the deployment ID')
+})
+
+test('same-commit restart rejects a changed commit ID', () => {
+  expect(() =>
+    assertSameCommitRestartChangedProduction({
+      health: health({
+        INSTANCE_ID: 'instance-2',
+        CC_DEPLOYMENT_ID: 'deployment-2',
+        CC_COMMIT_ID: 'commit-2'
+      }),
+      baseline: baseline(),
+      logContent: ''
+    })
+  ).toThrow('Expected sameCommitPolicy: restart to keep the same commit ID')
+})
+
+test('same-commit restart rejects a build marker in the log, proving the cache was not reused', () => {
+  expect(() =>
+    assertSameCommitRestartChangedProduction({
+      health: health({
+        INSTANCE_ID: 'instance-2',
+        CC_DEPLOYMENT_ID: 'deployment-2'
+      }),
+      baseline: baseline(),
+      logContent: 'fixture-build ran during install'
+    })
+  ).toThrow('Expected restart to reuse cache without a new install marker')
+})
+
+test('same-commit rebuild accepts changed production identifiers with cache and build markers', () => {
+  expect(() =>
+    assertSameCommitRebuildChangedProduction({
+      health: health({
+        INSTANCE_ID: 'instance-2',
+        CC_DEPLOYMENT_ID: 'deployment-2'
+      }),
+      baseline: baseline(),
+      logContent: 'without using cache, ran fixture-build'
+    })
+  ).not.toThrow()
+})
+
+test('same-commit rebuild rejects a missing instance ID', () => {
+  expect(() =>
+    assertSameCommitRebuildChangedProduction({
+      health: health({ INSTANCE_ID: null }),
+      baseline: baseline(),
+      logContent: ''
+    })
+  ).toThrow('Expected sameCommitPolicy: rebuild to report a new instance ID')
+})
+
+test('same-commit rebuild rejects an unchanged instance ID', () => {
+  expect(() =>
+    assertSameCommitRebuildChangedProduction({
+      health: health({ CC_DEPLOYMENT_ID: 'deployment-2' }),
+      baseline: baseline(),
+      logContent: ''
+    })
+  ).toThrow('Expected sameCommitPolicy: rebuild to change the instance ID')
+})
+
+test('same-commit rebuild rejects an unchanged deployment ID', () => {
+  expect(() =>
+    assertSameCommitRebuildChangedProduction({
+      health: health({ INSTANCE_ID: 'instance-2' }),
+      baseline: baseline(),
+      logContent: ''
+    })
+  ).toThrow('Expected sameCommitPolicy: rebuild to change the deployment ID')
+})
+
+test('same-commit rebuild rejects a changed commit ID', () => {
+  expect(() =>
+    assertSameCommitRebuildChangedProduction({
+      health: health({
+        INSTANCE_ID: 'instance-2',
+        CC_DEPLOYMENT_ID: 'deployment-2',
+        CC_COMMIT_ID: 'commit-2'
+      }),
+      baseline: baseline(),
+      logContent: ''
+    })
+  ).toThrow('Expected sameCommitPolicy: rebuild to keep the same commit ID')
+})
+
+test('same-commit rebuild rejects a log missing the without-using-cache message', () => {
+  expect(() =>
+    assertSameCommitRebuildChangedProduction({
+      health: health({
+        INSTANCE_ID: 'instance-2',
+        CC_DEPLOYMENT_ID: 'deployment-2'
+      }),
+      baseline: baseline(),
+      logContent: 'fixture-build ran during install'
+    })
+  ).toThrow('Expected sameCommitPolicy: rebuild to report without using cache')
+})
+
+test('same-commit rebuild rejects a log missing the build marker, proving the cache was reused', () => {
+  expect(() =>
+    assertSameCommitRebuildChangedProduction({
+      health: health({
+        INSTANCE_ID: 'instance-2',
+        CC_DEPLOYMENT_ID: 'deployment-2'
+      }),
+      baseline: baseline(),
+      logContent: 'without using cache'
+    })
+  ).toThrow('Expected sameCommitPolicy: rebuild to emit a new install marker')
+})
+
+test('build-failure accepts a preserved instance ID with the build-failure marker', () => {
+  expect(() =>
+    assertBuildFailurePreservedProduction({
+      health: health(),
+      baseline: baseline(),
+      logContent: 'fixture-build-failure logged'
+    })
+  ).not.toThrow()
+})
+
+test('build-failure rejects a changed instance ID', () => {
+  expect(() =>
+    assertBuildFailurePreservedProduction({
+      health: health({ INSTANCE_ID: 'instance-2' }),
+      baseline: baseline(),
+      logContent: 'fixture-build-failure logged'
+    })
+  ).toThrow(
+    'Expected build-failure deployment to preserve the prior healthy instance ID'
+  )
+})
+
+test('build-failure rejects a log missing the build-failure marker', () => {
+  expect(() =>
+    assertBuildFailurePreservedProduction({
+      health: health(),
+      baseline: baseline(),
+      logContent: 'nothing relevant here'
+    })
+  ).toThrow(
+    'Expected build-failure log to contain the deterministic fixture marker'
+  )
+})
+
+test('startup-failure accepts a preserved instance ID with the startup-failure marker', () => {
+  expect(() =>
+    assertStartupFailurePreservedProduction({
+      health: health(),
+      baseline: baseline(),
+      logContent: 'fixture-startup-failure logged'
+    })
+  ).not.toThrow()
+})
+
+test('startup-failure rejects a changed instance ID', () => {
+  expect(() =>
+    assertStartupFailurePreservedProduction({
+      health: health({ INSTANCE_ID: 'instance-2' }),
+      baseline: baseline(),
+      logContent: 'fixture-startup-failure logged'
+    })
+  ).toThrow(
+    'Expected startup-failure deployment to preserve the prior healthy instance ID'
+  )
+})
+
+test('startup-failure rejects a log missing the startup-failure marker', () => {
+  expect(() =>
+    assertStartupFailurePreservedProduction({
+      health: health(),
+      baseline: baseline(),
+      logContent: 'nothing relevant here'
+    })
+  ).toThrow(
+    'Expected startup-failure log to contain the fixture startup marker'
+  )
+})
+
+test('divergent rejection accepts preserved production identifiers with a non-fast-forward marker', () => {
+  expect(() =>
+    assertDivergentRejectionPreservedProduction({
+      health: health(),
+      baseline: baseline(),
+      logContent: 'error: non-fast-forward'
+    })
+  ).not.toThrow()
+})
+
+test('divergent rejection rejects a changed instance ID', () => {
+  expect(() =>
+    assertDivergentRejectionPreservedProduction({
+      health: health({ INSTANCE_ID: 'instance-2' }),
+      baseline: baseline(),
+      logContent: 'non-fast-forward'
+    })
+  ).toThrow(
+    'Expected divergent rejection to preserve the prior healthy instance ID'
+  )
+})
+
+test('divergent rejection rejects a changed deployment ID', () => {
+  expect(() =>
+    assertDivergentRejectionPreservedProduction({
+      health: health({ CC_DEPLOYMENT_ID: 'deployment-2' }),
+      baseline: baseline(),
+      logContent: 'non-fast-forward'
+    })
+  ).toThrow(
+    'Expected divergent rejection to preserve the prior healthy deployment ID'
+  )
+})
+
+test('divergent rejection rejects a changed commit ID', () => {
+  expect(() =>
+    assertDivergentRejectionPreservedProduction({
+      health: health({ CC_COMMIT_ID: 'commit-2' }),
+      baseline: baseline(),
+      logContent: 'non-fast-forward'
+    })
+  ).toThrow(
+    'Expected divergent rejection to preserve the prior healthy commit ID'
+  )
+})
+
+test.each([
+  'not a simple fast-forward',
+  'non-fast-forward',
+  '[rejected]',
+  'fetch first',
+  'Updates were rejected'
+])('divergent rejection accepts the non-fast-forward marker %j', marker => {
+  expect(() =>
+    assertDivergentRejectionPreservedProduction({
+      health: health(),
+      baseline: baseline(),
+      logContent: `git said: ${marker}`
+    })
+  ).not.toThrow()
+})
+
+test('divergent rejection rejects a log with none of the non-fast-forward markers', () => {
+  expect(() =>
+    assertDivergentRejectionPreservedProduction({
+      health: health(),
+      baseline: baseline(),
+      logContent: 'push succeeded unexpectedly'
+    })
+  ).toThrow(
+    'Expected divergent deployment without force log to mention a non-fast-forward rejection'
+  )
+})
+
+test('forced deployment accepts changed commit and deployment IDs', () => {
+  expect(() =>
+    assertForcedDeploymentReplacedProduction({
+      health: health({
+        CC_COMMIT_ID: 'commit-2',
+        CC_DEPLOYMENT_ID: 'deployment-2'
+      }),
+      baseline: baseline()
+    })
+  ).not.toThrow()
+})
+
+test('forced deployment rejects an unchanged commit ID', () => {
+  expect(() =>
+    assertForcedDeploymentReplacedProduction({
+      health: health({ CC_DEPLOYMENT_ID: 'deployment-2' }),
+      baseline: baseline()
+    })
+  ).toThrow(
+    'Expected forced divergent deployment to change the live commit ID'
+  )
+})
+
+test('forced deployment rejects an unchanged deployment ID', () => {
+  expect(() =>
+    assertForcedDeploymentReplacedProduction({
+      health: health({ CC_COMMIT_ID: 'commit-2' }),
+      baseline: baseline()
+    })
+  ).toThrow(
+    'Expected forced divergent deployment to change the live deployment ID'
+  )
+})
+
+test('timeout outcome accepts a completed deployment serving the timeout commit', () => {
+  expect(() =>
+    assertTimeoutOutcome({
+      outcome: 'completed',
+      health: health({ CC_COMMIT_ID: 'commit-2' }),
+      expectedCancelledCommitID: 'commit-2',
+      previousInstanceId: 'instance-1'
+    })
+  ).not.toThrow()
+})
+
+test('timeout outcome rejects a completed deployment serving the wrong commit', () => {
+  expect(() =>
+    assertTimeoutOutcome({
+      outcome: 'completed',
+      health: health({ CC_COMMIT_ID: 'commit-1' }),
+      expectedCancelledCommitID: 'commit-2',
+      previousInstanceId: 'instance-1'
+    })
+  ).toThrow(
+    'Expected the completed timed-out deployment to serve the timeout commit'
+  )
+})
+
+test('timeout outcome accepts a cancelled deployment preserving the prior instance ID', () => {
+  expect(() =>
+    assertTimeoutOutcome({
+      outcome: 'cancelled',
+      health: health({ INSTANCE_ID: 'instance-1' }),
+      expectedCancelledCommitID: 'commit-2',
+      previousInstanceId: 'instance-1'
+    })
+  ).not.toThrow()
+})
+
+test('timeout outcome rejects a cancelled deployment with a changed instance ID', () => {
+  expect(() =>
+    assertTimeoutOutcome({
+      outcome: 'cancelled',
+      health: health({ INSTANCE_ID: 'instance-2' }),
+      expectedCancelledCommitID: 'commit-2',
+      previousInstanceId: 'instance-1'
+    })
+  ).toThrow(
+    'Expected the cancelled timed-out deployment to preserve the prior healthy forced instance ID'
+  )
+})
+
+test('timeout outcome rejects a failed deployment with a changed instance ID', () => {
+  expect(() =>
+    assertTimeoutOutcome({
+      outcome: 'failed',
+      health: health({ INSTANCE_ID: 'instance-2' }),
+      expectedCancelledCommitID: 'commit-2',
+      previousInstanceId: 'instance-1'
+    })
+  ).toThrow(
+    'Expected the failed timed-out deployment to preserve the prior healthy forced instance ID'
+  )
+})
+
+test('parseBaselineState accepts the shape written by capture-baseline-state', () => {
+  const raw = {
+    activity: [{ some: 'entry' }],
+    instanceId: 'instance-1',
+    deploymentId: 'deployment-1',
+    commitId: 'commit-1'
+  }
+
+  expect(parseBaselineState(raw)).toEqual(raw)
+})
+
+test('parseBaselineState rejects a non-object value', () => {
+  expect(() => parseBaselineState('not an object')).toThrow(
+    'baseline state must be an object'
+  )
+})
+
+test('parseBaselineState rejects a missing activity array', () => {
+  expect(() =>
+    parseBaselineState({
+      instanceId: 'instance-1',
+      deploymentId: 'deployment-1',
+      commitId: 'commit-1'
+    })
+  ).toThrow('baseline state.activity must be an array')
+})
+
+test('parseBaselineState rejects a numeric instanceId', () => {
+  expect(() =>
+    parseBaselineState({
+      activity: [],
+      instanceId: 123,
+      deploymentId: 'deployment-1',
+      commitId: 'commit-1'
+    })
+  ).toThrow('baseline state.instanceId must be a string')
+})

--- a/src/e2e/scenario-assertions.test.ts
+++ b/src/e2e/scenario-assertions.test.ts
@@ -1,5 +1,10 @@
 import { expect, test } from 'vitest'
-import type { FixtureHealth } from './fixture-app.ts'
+import {
+  FIXTURE_BUILD_FAILURE_MARKER,
+  FIXTURE_BUILD_MARKER,
+  FIXTURE_STARTUP_FAILURE_MARKER,
+  type FixtureHealth
+} from './fixture-app.ts'
 import {
   assertBuildFailurePreservedProduction,
   assertDivergentRejectionPreservedProduction,
@@ -136,7 +141,7 @@ test('same-commit restart rejects a build marker in the log, proving the cache w
         CC_DEPLOYMENT_ID: 'deployment-2'
       }),
       baseline: baseline(),
-      logContent: 'fixture-build ran during install'
+      logContent: `${FIXTURE_BUILD_MARKER} ran during install`
     })
   ).toThrow('Expected restart to reuse cache without a new install marker')
 })
@@ -149,7 +154,7 @@ test('same-commit rebuild accepts changed production identifiers with cache and 
         CC_DEPLOYMENT_ID: 'deployment-2'
       }),
       baseline: baseline(),
-      logContent: 'without using cache, ran fixture-build'
+      logContent: `without using cache, ran ${FIXTURE_BUILD_MARKER}`
     })
   ).not.toThrow()
 })
@@ -206,7 +211,7 @@ test('same-commit rebuild rejects a log missing the without-using-cache message'
         CC_DEPLOYMENT_ID: 'deployment-2'
       }),
       baseline: baseline(),
-      logContent: 'fixture-build ran during install'
+      logContent: `${FIXTURE_BUILD_MARKER} ran during install`
     })
   ).toThrow('Expected sameCommitPolicy: rebuild to report without using cache')
 })
@@ -229,7 +234,7 @@ test('build-failure accepts a preserved instance ID with the build-failure marke
     assertBuildFailurePreservedProduction({
       health: health(),
       baseline: baseline(),
-      logContent: 'fixture-build-failure logged'
+      logContent: `${FIXTURE_BUILD_FAILURE_MARKER} logged`
     })
   ).not.toThrow()
 })
@@ -239,7 +244,7 @@ test('build-failure rejects a changed instance ID', () => {
     assertBuildFailurePreservedProduction({
       health: health({ INSTANCE_ID: 'instance-2' }),
       baseline: baseline(),
-      logContent: 'fixture-build-failure logged'
+      logContent: `${FIXTURE_BUILD_FAILURE_MARKER} logged`
     })
   ).toThrow(
     'Expected build-failure deployment to preserve the prior healthy instance ID'
@@ -263,7 +268,7 @@ test('startup-failure accepts a preserved instance ID with the startup-failure m
     assertStartupFailurePreservedProduction({
       health: health(),
       baseline: baseline(),
-      logContent: 'fixture-startup-failure logged'
+      logContent: `${FIXTURE_STARTUP_FAILURE_MARKER} logged`
     })
   ).not.toThrow()
 })
@@ -273,7 +278,7 @@ test('startup-failure rejects a changed instance ID', () => {
     assertStartupFailurePreservedProduction({
       health: health({ INSTANCE_ID: 'instance-2' }),
       baseline: baseline(),
-      logContent: 'fixture-startup-failure logged'
+      logContent: `${FIXTURE_STARTUP_FAILURE_MARKER} logged`
     })
   ).toThrow(
     'Expected startup-failure deployment to preserve the prior healthy instance ID'
@@ -384,9 +389,7 @@ test('forced deployment rejects an unchanged commit ID', () => {
       health: health({ CC_DEPLOYMENT_ID: 'deployment-2' }),
       baseline: baseline()
     })
-  ).toThrow(
-    'Expected forced divergent deployment to change the live commit ID'
-  )
+  ).toThrow('Expected forced divergent deployment to change the live commit ID')
 })
 
 test('forced deployment rejects an unchanged deployment ID', () => {

--- a/src/e2e/scenario-assertions.ts
+++ b/src/e2e/scenario-assertions.ts
@@ -1,0 +1,281 @@
+import {
+  FIXTURE_BUILD_FAILURE_MARKER,
+  FIXTURE_BUILD_MARKER,
+  FIXTURE_STARTUP_FAILURE_MARKER,
+  type FixtureHealth
+} from './fixture-app.ts'
+
+const REBUILD_WITHOUT_CACHE_MESSAGE = 'without using cache'
+
+const nonFastForwardMarkers = [
+  'not a simple fast-forward',
+  'non-fast-forward',
+  '[rejected]',
+  'fetch first',
+  'Updates were rejected'
+]
+
+export type BaselineState = {
+  activity: unknown[]
+  instanceId: string
+  deploymentId: string
+  commitId: string
+}
+
+export function parseBaselineState(value: unknown): BaselineState {
+  const record = readRecord(value, 'baseline state')
+
+  if (!Array.isArray(record.activity)) {
+    throw new Error('baseline state.activity must be an array')
+  }
+
+  return {
+    activity: record.activity,
+    instanceId: readString(record.instanceId, 'baseline state.instanceId'),
+    deploymentId: readString(
+      record.deploymentId,
+      'baseline state.deploymentId'
+    ),
+    commitId: readString(record.commitId, 'baseline state.commitId')
+  }
+}
+
+function readRecord(value: unknown, field: string): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${field} must be an object`)
+  }
+
+  return value as Record<string, unknown>
+}
+
+function readString(value: unknown, field: string): string {
+  if (typeof value !== 'string') {
+    throw new Error(`${field} must be a string`)
+  }
+
+  return value
+}
+
+export function assertSameCommitIgnorePreservedProduction({
+  health,
+  baseline
+}: {
+  health: FixtureHealth
+  baseline: BaselineState
+}): void {
+  if (health.INSTANCE_ID !== baseline.instanceId) {
+    throw new Error(
+      'Expected sameCommitPolicy: ignore to keep the same instance ID'
+    )
+  }
+  if (health.CC_DEPLOYMENT_ID !== baseline.deploymentId) {
+    throw new Error(
+      'Expected sameCommitPolicy: ignore to keep the same deployment ID'
+    )
+  }
+  if (health.CC_COMMIT_ID !== baseline.commitId) {
+    throw new Error(
+      'Expected sameCommitPolicy: ignore to keep the same commit ID'
+    )
+  }
+}
+
+export function assertSameCommitRestartChangedProduction({
+  health,
+  baseline,
+  logContent
+}: {
+  health: FixtureHealth
+  baseline: BaselineState
+  logContent: string
+}): void {
+  if (!health.INSTANCE_ID) {
+    throw new Error(
+      'Expected sameCommitPolicy: restart to report a new instance ID'
+    )
+  }
+  if (health.INSTANCE_ID === baseline.instanceId) {
+    throw new Error(
+      'Expected sameCommitPolicy: restart to change the instance ID'
+    )
+  }
+  if (health.CC_DEPLOYMENT_ID === baseline.deploymentId) {
+    throw new Error(
+      'Expected sameCommitPolicy: restart to change the deployment ID'
+    )
+  }
+  if (health.CC_COMMIT_ID !== baseline.commitId) {
+    throw new Error(
+      'Expected sameCommitPolicy: restart to keep the same commit ID'
+    )
+  }
+
+  if (logContent.includes(FIXTURE_BUILD_MARKER)) {
+    throw new Error(
+      'Expected restart to reuse cache without a new install marker'
+    )
+  }
+}
+
+export function assertSameCommitRebuildChangedProduction({
+  health,
+  baseline,
+  logContent
+}: {
+  health: FixtureHealth
+  baseline: BaselineState
+  logContent: string
+}): void {
+  if (!health.INSTANCE_ID) {
+    throw new Error(
+      'Expected sameCommitPolicy: rebuild to report a new instance ID'
+    )
+  }
+  if (health.INSTANCE_ID === baseline.instanceId) {
+    throw new Error(
+      'Expected sameCommitPolicy: rebuild to change the instance ID'
+    )
+  }
+  if (health.CC_DEPLOYMENT_ID === baseline.deploymentId) {
+    throw new Error(
+      'Expected sameCommitPolicy: rebuild to change the deployment ID'
+    )
+  }
+  if (health.CC_COMMIT_ID !== baseline.commitId) {
+    throw new Error(
+      'Expected sameCommitPolicy: rebuild to keep the same commit ID'
+    )
+  }
+
+  if (!logContent.includes(REBUILD_WITHOUT_CACHE_MESSAGE)) {
+    throw new Error(
+      'Expected sameCommitPolicy: rebuild to report without using cache'
+    )
+  }
+  if (!logContent.includes(FIXTURE_BUILD_MARKER)) {
+    throw new Error(
+      'Expected sameCommitPolicy: rebuild to emit a new install marker'
+    )
+  }
+}
+
+export function assertBuildFailurePreservedProduction({
+  health,
+  baseline,
+  logContent
+}: {
+  health: FixtureHealth
+  baseline: BaselineState
+  logContent: string
+}): void {
+  if (health.INSTANCE_ID !== baseline.instanceId) {
+    throw new Error(
+      'Expected build-failure deployment to preserve the prior healthy instance ID'
+    )
+  }
+
+  if (!logContent.includes(FIXTURE_BUILD_FAILURE_MARKER)) {
+    throw new Error(
+      'Expected build-failure log to contain the deterministic fixture marker'
+    )
+  }
+}
+
+export function assertStartupFailurePreservedProduction({
+  health,
+  baseline,
+  logContent
+}: {
+  health: FixtureHealth
+  baseline: BaselineState
+  logContent: string
+}): void {
+  if (health.INSTANCE_ID !== baseline.instanceId) {
+    throw new Error(
+      'Expected startup-failure deployment to preserve the prior healthy instance ID'
+    )
+  }
+
+  if (!logContent.includes(FIXTURE_STARTUP_FAILURE_MARKER)) {
+    throw new Error(
+      'Expected startup-failure log to contain the fixture startup marker'
+    )
+  }
+}
+
+export function assertDivergentRejectionPreservedProduction({
+  health,
+  baseline,
+  logContent
+}: {
+  health: FixtureHealth
+  baseline: BaselineState
+  logContent: string
+}): void {
+  if (health.INSTANCE_ID !== baseline.instanceId) {
+    throw new Error(
+      'Expected divergent rejection to preserve the prior healthy instance ID'
+    )
+  }
+  if (health.CC_DEPLOYMENT_ID !== baseline.deploymentId) {
+    throw new Error(
+      'Expected divergent rejection to preserve the prior healthy deployment ID'
+    )
+  }
+  if (health.CC_COMMIT_ID !== baseline.commitId) {
+    throw new Error(
+      'Expected divergent rejection to preserve the prior healthy commit ID'
+    )
+  }
+
+  if (!nonFastForwardMarkers.some(marker => logContent.includes(marker))) {
+    throw new Error(
+      'Expected divergent deployment without force log to mention a non-fast-forward rejection'
+    )
+  }
+}
+
+export function assertForcedDeploymentReplacedProduction({
+  health,
+  baseline
+}: {
+  health: FixtureHealth
+  baseline: BaselineState
+}): void {
+  if (health.CC_COMMIT_ID === baseline.commitId) {
+    throw new Error(
+      'Expected forced divergent deployment to change the live commit ID'
+    )
+  }
+  if (health.CC_DEPLOYMENT_ID === baseline.deploymentId) {
+    throw new Error(
+      'Expected forced divergent deployment to change the live deployment ID'
+    )
+  }
+}
+
+export function assertTimeoutOutcome({
+  outcome,
+  health,
+  expectedCancelledCommitID,
+  previousInstanceId
+}: {
+  outcome: 'cancelled' | 'completed' | 'failed'
+  health: FixtureHealth
+  expectedCancelledCommitID: string
+  previousInstanceId: string
+}): void {
+  if (outcome === 'completed') {
+    if (health.CC_COMMIT_ID !== expectedCancelledCommitID) {
+      throw new Error(
+        'Expected the completed timed-out deployment to serve the timeout commit'
+      )
+    }
+  } else {
+    if (health.INSTANCE_ID !== previousInstanceId) {
+      throw new Error(
+        `Expected the ${outcome} timed-out deployment to preserve the prior healthy forced instance ID`
+      )
+    }
+  }
+}

--- a/src/e2e/scripts/assert-build-failure.ts
+++ b/src/e2e/scripts/assert-build-failure.ts
@@ -4,7 +4,10 @@ import {
   waitForHealthyDeployment,
   waitForNewFailedDeploymentActivity
 } from '../deployment-observer.ts'
-import { FIXTURE_BUILD_FAILURE_MARKER } from '../fixture-app.ts'
+import {
+  assertBuildFailurePreservedProduction,
+  parseBaselineState
+} from '../scenario-assertions.ts'
 import {
   createFetchHealth,
   createRunCommand,
@@ -34,7 +37,9 @@ if (actionOutcome !== 'failure') {
   throw new Error('Expected build-failure deployment to fail')
 }
 
-const previousState = JSON.parse(await readFile(statePath, 'utf8'))
+const previousState = parseBaselineState(
+  JSON.parse(await readFile(statePath, 'utf8'))
+)
 const controller = createCleverController({
   cleverCLI,
   runCommand: createRunCommand()
@@ -43,7 +48,9 @@ const controller = createCleverController({
 const failedDeployment = await waitForNewFailedDeploymentActivity({
   appId,
   expectedCommitID,
-  previousActivity: previousState.activity,
+  previousActivity: previousState.activity as Awaited<
+    ReturnType<typeof controller.listActivity>
+  >,
   listActivity: controller.listActivity
 })
 
@@ -61,18 +68,12 @@ const health = await waitForHealthyDeployment({
   fetchHealth: createFetchHealth()
 })
 
-if (health.INSTANCE_ID !== previousState.instanceId) {
-  throw new Error(
-    'Expected build-failure deployment to preserve the prior healthy instance ID'
-  )
-}
-
 const logContent = await readFile(logPath, 'utf8')
-if (!logContent.includes(FIXTURE_BUILD_FAILURE_MARKER)) {
-  throw new Error(
-    'Expected build-failure log to contain the deterministic fixture marker'
-  )
-}
+assertBuildFailurePreservedProduction({
+  health,
+  baseline: previousState,
+  logContent
+})
 
 await appendFile(
   githubOutput,

--- a/src/e2e/scripts/assert-divergent-rejection.ts
+++ b/src/e2e/scripts/assert-divergent-rejection.ts
@@ -2,6 +2,10 @@ import { appendFile, readFile } from 'node:fs/promises'
 import { createCleverController } from '../clever-client.ts'
 import { confirmRejectedDeploymentPreservesLiveApp } from '../deployment-observer.ts'
 import {
+  assertDivergentRejectionPreservedProduction,
+  parseBaselineState
+} from '../scenario-assertions.ts'
+import {
   createFetchHealth,
   createRunCommand,
   resolveCleverCLI
@@ -22,7 +26,9 @@ if (actionOutcome !== 'failure') {
   throw new Error('Expected divergent deployment without force to fail')
 }
 
-const previousState = JSON.parse(await readFile(statePath, 'utf8'))
+const previousState = parseBaselineState(
+  JSON.parse(await readFile(statePath, 'utf8'))
+)
 const controller = createCleverController({
   cleverCLI,
   runCommand: createRunCommand()
@@ -36,7 +42,9 @@ const health = await confirmRejectedDeploymentPreservesLiveApp({
   appId,
   healthURL,
   expectedScenario: 'healthy',
-  previousActivity: previousState.activity,
+  previousActivity: previousState.activity as Awaited<
+    ReturnType<typeof controller.listActivity>
+  >,
   previousCommitID: previousState.commitId,
   previousDeploymentID: previousState.deploymentId,
   listActivity: controller.listActivity,
@@ -46,35 +54,12 @@ const health = await confirmRejectedDeploymentPreservesLiveApp({
   pollIntervalMs: 5_000
 })
 
-if (health.INSTANCE_ID !== previousState.instanceId) {
-  throw new Error(
-    'Expected divergent rejection to preserve the prior healthy instance ID'
-  )
-}
-if (health.CC_DEPLOYMENT_ID !== previousState.deploymentId) {
-  throw new Error(
-    'Expected divergent rejection to preserve the prior healthy deployment ID'
-  )
-}
-if (health.CC_COMMIT_ID !== previousState.commitId) {
-  throw new Error(
-    'Expected divergent rejection to preserve the prior healthy commit ID'
-  )
-}
-
 const logContent = await readFile(logPath, 'utf8')
-const nonFastForwardMarkers = [
-  'not a simple fast-forward',
-  'non-fast-forward',
-  '[rejected]',
-  'fetch first',
-  'Updates were rejected'
-]
-if (!nonFastForwardMarkers.some(marker => logContent.includes(marker))) {
-  throw new Error(
-    'Expected divergent deployment without force log to mention a non-fast-forward rejection'
-  )
-}
+assertDivergentRejectionPreservedProduction({
+  health,
+  baseline: previousState,
+  logContent
+})
 
 await appendFile(
   githubOutput,

--- a/src/e2e/scripts/assert-startup-failure.ts
+++ b/src/e2e/scripts/assert-startup-failure.ts
@@ -4,7 +4,10 @@ import {
   waitForHealthyDeployment,
   waitForNewFailedDeploymentActivity
 } from '../deployment-observer.ts'
-import { FIXTURE_STARTUP_FAILURE_MARKER } from '../fixture-app.ts'
+import {
+  assertStartupFailurePreservedProduction,
+  parseBaselineState
+} from '../scenario-assertions.ts'
 import {
   createFetchHealth,
   createRunCommand,
@@ -34,7 +37,9 @@ if (actionOutcome !== 'failure') {
   throw new Error('Expected startup-failure deployment to fail')
 }
 
-const previousState = JSON.parse(await readFile(statePath, 'utf8'))
+const previousState = parseBaselineState(
+  JSON.parse(await readFile(statePath, 'utf8'))
+)
 const controller = createCleverController({
   cleverCLI,
   runCommand: createRunCommand()
@@ -43,7 +48,9 @@ const controller = createCleverController({
 const failedDeployment = await waitForNewFailedDeploymentActivity({
   appId,
   expectedCommitID,
-  previousActivity: previousState.activity,
+  previousActivity: previousState.activity as Awaited<
+    ReturnType<typeof controller.listActivity>
+  >,
   listActivity: controller.listActivity
 })
 
@@ -61,18 +68,12 @@ const health = await waitForHealthyDeployment({
   fetchHealth: createFetchHealth()
 })
 
-if (health.INSTANCE_ID !== previousState.instanceId) {
-  throw new Error(
-    'Expected startup-failure deployment to preserve the prior healthy instance ID'
-  )
-}
-
 const logContent = await readFile(logPath, 'utf8')
-if (!logContent.includes(FIXTURE_STARTUP_FAILURE_MARKER)) {
-  throw new Error(
-    'Expected startup-failure log to contain the fixture startup marker'
-  )
-}
+assertStartupFailurePreservedProduction({
+  health,
+  baseline: previousState,
+  logContent
+})
 
 await appendFile(
   githubOutput,

--- a/src/e2e/scripts/observe-divergent-force.ts
+++ b/src/e2e/scripts/observe-divergent-force.ts
@@ -2,6 +2,10 @@ import { appendFile, readFile } from 'node:fs/promises'
 import { createCleverController } from '../clever-client.ts'
 import { waitForNewHealthyDeployment } from '../deployment-observer.ts'
 import {
+  assertForcedDeploymentReplacedProduction,
+  parseBaselineState
+} from '../scenario-assertions.ts'
+import {
   createFetchHealth,
   createRunCommand,
   resolveCleverCLI
@@ -28,7 +32,9 @@ if (actionOutcome !== 'success') {
   throw new Error('Expected divergent deployment with force to succeed')
 }
 
-const previousState = JSON.parse(await readFile(statePath, 'utf8'))
+const previousState = parseBaselineState(
+  JSON.parse(await readFile(statePath, 'utf8'))
+)
 const controller = createCleverController({
   cleverCLI,
   runCommand: createRunCommand()
@@ -43,21 +49,17 @@ const result = await waitForNewHealthyDeployment({
   healthURL,
   expectedScenario: 'healthy',
   expectedCommitID,
-  previousActivity: previousState.activity,
+  previousActivity: previousState.activity as Awaited<
+    ReturnType<typeof controller.listActivity>
+  >,
   listActivity: controller.listActivity,
   fetchHealth: createFetchHealth()
 })
 
-if (result.health.CC_COMMIT_ID === previousState.commitId) {
-  throw new Error(
-    'Expected forced divergent deployment to change the live commit ID'
-  )
-}
-if (result.health.CC_DEPLOYMENT_ID === previousState.deploymentId) {
-  throw new Error(
-    'Expected forced divergent deployment to change the live deployment ID'
-  )
-}
+assertForcedDeploymentReplacedProduction({
+  health: result.health,
+  baseline: previousState
+})
 
 await appendFile(
   githubOutput,

--- a/src/e2e/scripts/observe-same-commit-ignore.ts
+++ b/src/e2e/scripts/observe-same-commit-ignore.ts
@@ -5,6 +5,10 @@ import {
   waitForHealthyDeployment
 } from '../deployment-observer.ts'
 import {
+  assertSameCommitIgnorePreservedProduction,
+  parseBaselineState
+} from '../scenario-assertions.ts'
+import {
   createFetchHealth,
   createRunCommand,
   resolveCleverCLI
@@ -24,7 +28,9 @@ if (actionOutcome !== 'success') {
   throw new Error('Expected sameCommitPolicy: ignore to succeed')
 }
 
-const previousState = JSON.parse(await readFile(statePath, 'utf8'))
+const previousState = parseBaselineState(
+  JSON.parse(await readFile(statePath, 'utf8'))
+)
 const controller = createCleverController({
   cleverCLI,
   runCommand: createRunCommand()
@@ -32,7 +38,9 @@ const controller = createCleverController({
 
 await confirmNoNewDeploymentActivity({
   appId,
-  previousActivity: previousState.activity,
+  previousActivity: previousState.activity as Awaited<
+    ReturnType<typeof controller.listActivity>
+  >,
   listActivity: controller.listActivity,
   settleTimeoutMs: 15_000,
   pollIntervalMs: 5_000
@@ -52,21 +60,10 @@ const health = await waitForHealthyDeployment({
   fetchHealth: createFetchHealth()
 })
 
-if (health.INSTANCE_ID !== previousState.instanceId) {
-  throw new Error(
-    'Expected sameCommitPolicy: ignore to keep the same instance ID'
-  )
-}
-if (health.CC_DEPLOYMENT_ID !== previousState.deploymentId) {
-  throw new Error(
-    'Expected sameCommitPolicy: ignore to keep the same deployment ID'
-  )
-}
-if (health.CC_COMMIT_ID !== previousState.commitId) {
-  throw new Error(
-    'Expected sameCommitPolicy: ignore to keep the same commit ID'
-  )
-}
+assertSameCommitIgnorePreservedProduction({
+  health,
+  baseline: previousState
+})
 
 await appendFile(
   githubOutput,

--- a/src/e2e/scripts/observe-same-commit-rebuild.ts
+++ b/src/e2e/scripts/observe-same-commit-rebuild.ts
@@ -4,7 +4,10 @@ import {
   waitForHealthyDeployment,
   waitForNewSuccessfulDeploymentActivity
 } from '../deployment-observer.ts'
-import { FIXTURE_BUILD_MARKER } from '../fixture-app.ts'
+import {
+  assertSameCommitRebuildChangedProduction,
+  parseBaselineState
+} from '../scenario-assertions.ts'
 import {
   createFetchHealth,
   createRunCommand,
@@ -26,7 +29,9 @@ if (actionOutcome !== 'success') {
   throw new Error('Expected sameCommitPolicy: rebuild to succeed')
 }
 
-const previousState = JSON.parse(await readFile(statePath, 'utf8'))
+const previousState = parseBaselineState(
+  JSON.parse(await readFile(statePath, 'utf8'))
+)
 const controller = createCleverController({
   cleverCLI,
   runCommand: createRunCommand()
@@ -35,7 +40,9 @@ const controller = createCleverController({
 const deployment = await waitForNewSuccessfulDeploymentActivity({
   appId,
   expectedCommitID: previousState.commitId,
-  previousActivity: previousState.activity,
+  previousActivity: previousState.activity as Awaited<
+    ReturnType<typeof controller.listActivity>
+  >,
   listActivity: controller.listActivity
 })
 
@@ -53,38 +60,12 @@ const health = await waitForHealthyDeployment({
   fetchHealth: createFetchHealth()
 })
 
-if (!health.INSTANCE_ID) {
-  throw new Error(
-    'Expected sameCommitPolicy: rebuild to report a new instance ID'
-  )
-}
-if (health.INSTANCE_ID === previousState.instanceId) {
-  throw new Error(
-    'Expected sameCommitPolicy: rebuild to change the instance ID'
-  )
-}
-if (health.CC_DEPLOYMENT_ID === previousState.deploymentId) {
-  throw new Error(
-    'Expected sameCommitPolicy: rebuild to change the deployment ID'
-  )
-}
-if (health.CC_COMMIT_ID !== previousState.commitId) {
-  throw new Error(
-    'Expected sameCommitPolicy: rebuild to keep the same commit ID'
-  )
-}
-
 const logContent = await readFile(logPath, 'utf8')
-if (!logContent.includes('without using cache')) {
-  throw new Error(
-    'Expected sameCommitPolicy: rebuild to report without using cache'
-  )
-}
-if (!logContent.includes(FIXTURE_BUILD_MARKER)) {
-  throw new Error(
-    'Expected sameCommitPolicy: rebuild to emit a new install marker'
-  )
-}
+assertSameCommitRebuildChangedProduction({
+  health,
+  baseline: previousState,
+  logContent
+})
 
 await appendFile(
   githubOutput,

--- a/src/e2e/scripts/observe-same-commit-restart.ts
+++ b/src/e2e/scripts/observe-same-commit-restart.ts
@@ -4,7 +4,10 @@ import {
   waitForHealthyDeployment,
   waitForNewSuccessfulDeploymentActivity
 } from '../deployment-observer.ts'
-import { FIXTURE_BUILD_MARKER } from '../fixture-app.ts'
+import {
+  assertSameCommitRestartChangedProduction,
+  parseBaselineState
+} from '../scenario-assertions.ts'
 import {
   createFetchHealth,
   createRunCommand,
@@ -26,7 +29,9 @@ if (actionOutcome !== 'success') {
   throw new Error('Expected sameCommitPolicy: restart to succeed')
 }
 
-const previousState = JSON.parse(await readFile(statePath, 'utf8'))
+const previousState = parseBaselineState(
+  JSON.parse(await readFile(statePath, 'utf8'))
+)
 const controller = createCleverController({
   cleverCLI,
   runCommand: createRunCommand()
@@ -35,7 +40,9 @@ const controller = createCleverController({
 const deployment = await waitForNewSuccessfulDeploymentActivity({
   appId,
   expectedCommitID: previousState.commitId,
-  previousActivity: previousState.activity,
+  previousActivity: previousState.activity as Awaited<
+    ReturnType<typeof controller.listActivity>
+  >,
   listActivity: controller.listActivity
 })
 
@@ -53,33 +60,12 @@ const health = await waitForHealthyDeployment({
   fetchHealth: createFetchHealth()
 })
 
-if (!health.INSTANCE_ID) {
-  throw new Error(
-    'Expected sameCommitPolicy: restart to report a new instance ID'
-  )
-}
-if (health.INSTANCE_ID === previousState.instanceId) {
-  throw new Error(
-    'Expected sameCommitPolicy: restart to change the instance ID'
-  )
-}
-if (health.CC_DEPLOYMENT_ID === previousState.deploymentId) {
-  throw new Error(
-    'Expected sameCommitPolicy: restart to change the deployment ID'
-  )
-}
-if (health.CC_COMMIT_ID !== previousState.commitId) {
-  throw new Error(
-    'Expected sameCommitPolicy: restart to keep the same commit ID'
-  )
-}
-
 const logContent = await readFile(logPath, 'utf8')
-if (logContent.includes(FIXTURE_BUILD_MARKER)) {
-  throw new Error(
-    'Expected restart to reuse cache without a new install marker'
-  )
-}
+assertSameCommitRestartChangedProduction({
+  health,
+  baseline: previousState,
+  logContent
+})
 
 const activity = await controller.listActivity(appId)
 await writeFile(

--- a/src/e2e/scripts/observe-timeout-cancellation.ts
+++ b/src/e2e/scripts/observe-timeout-cancellation.ts
@@ -1,6 +1,7 @@
 import { appendFile } from 'node:fs/promises'
 import { createCleverController } from '../clever-client.ts'
 import { cancelTimedOutDeploymentPreservesLiveApp } from '../deployment-observer.ts'
+import { assertTimeoutOutcome } from '../scenario-assertions.ts'
 import {
   createFetchHealth,
   createRunCommand,
@@ -49,21 +50,18 @@ const result = await cancelTimedOutDeploymentPreservesLiveApp({
   pollIntervalMs: 5_000
 })
 
+assertTimeoutOutcome({
+  outcome: result.outcome,
+  health: result.health,
+  expectedCancelledCommitID,
+  previousInstanceId
+})
+
 if (result.outcome === 'completed') {
-  if (result.health.CC_COMMIT_ID !== expectedCancelledCommitID) {
-    throw new Error(
-      'Expected the completed timed-out deployment to serve the timeout commit'
-    )
-  }
   console.log(
     'Timed-out deployment completed before cancellation; it is live and healthy'
   )
 } else {
-  if (result.health.INSTANCE_ID !== previousInstanceId) {
-    throw new Error(
-      `Expected the ${result.outcome} timed-out deployment to preserve the prior healthy forced instance ID`
-    )
-  }
   console.log(`Timed-out deployment settled as ${result.outcome}`)
 }
 


### PR DESCRIPTION
Eight glue scripts under `src/e2e/scripts/` held the logic deciding whether a live scenario passed: whether `restart` reused the build cache, whether `rebuild` did not, whether a failed deploy preserved production, how the timeout cancellation race resolves. None of it had unit tests, because these are top-level-await modules a test cannot import without running them. Only a credentialed live run exercised it.

They also parsed their baseline state with a bare `JSON.parse`, so every field read off it was `any` in a repo configured `strict` with `noUncheckedIndexedAccess`.

The rules now live in `scenario-assertions.ts` as pure functions with a validated state parser, covered by 45 cases. The scripts go back to being glue. This is a pure extraction: every comparison operator and all 21 error messages are byte-identical to the originals, checked mechanically rather than by eye.

The cases worth having are the ones a live run samples badly. `restart` and `rebuild` expect the build marker with opposite polarity, the timeout race resolves two ways depending on whether cancellation beats completion, and a non-fast-forward rejection is accepted on any of five git phrasings.
