### PR TITLE
doc: correct the manual e2e dispatch constraints

### DIFF
--- a/docs/e2e-operations.md
+++ b/docs/e2e-operations.md
@@ -19,9 +19,9 @@ It does not pass an organisation owner.
 
 ## Manual dispatch
 
-Run `.github/workflows/e2e-manual.yml` from the branch whose current head matches the pull request head.
+Run `.github/workflows/e2e-manual.yml` from `master`. The workflow rejects a dispatch from any other ref.
 Pass the full 40-character internal pull request head SHA as `head_sha`.
-The workflow rejects closed pull requests, fork pull requests, stale SHAs, and branch selections whose workflow run SHA does not match the input SHA.
+The workflow resolves that SHA to exactly one open pull request in this repository, and rejects closed pull requests, fork pull requests, and SHAs that are no longer the head of an open pull request.
 After approval, it checks the pull request head again before app creation.
 
 ## Candidate setup


### PR DESCRIPTION
The manual dispatch section told you to run the workflow from the pull request's own branch. `resolve-manual-candidate.ts` requires `refs/heads/master` and rejects anything else, so following the doc gets you an immediate failure at the resolve gate. I hit this while triggering a run.

The same paragraph also claimed the workflow rejects "branch selections whose workflow run SHA does not match the input SHA". No such comparison exists; the real constraint is the ref check above. The other three rejections it lists are genuine and stay.

Both lines now match what the code enforces: the ref check in `resolve-manual-candidate.ts`, and the open / non-fork / current-head filtering in `filterManualCandidatePulls`.
