### PR TITLE
chore: add step level timeouts to the e2e suite

### DIFF
--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -35,7 +35,7 @@ jobs:
   create-and-delete:
     name: Create and delete app
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: read
@@ -96,11 +96,13 @@ jobs:
 
       - name: Install workflow pinning dependencies
         if: steps.candidate-state.outputs.proceed == 'true'
+        timeout-minutes: 5
         working-directory: .workflow-source
         run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Install candidate dependencies
         if: steps.candidate-state.outputs.proceed == 'true'
+        timeout-minutes: 5
         working-directory: .candidate-source
         run: pnpm install --frozen-lockfile --ignore-scripts
 
@@ -172,6 +174,7 @@ jobs:
       - name: Deploy healthy fixture commit
         if: steps.candidate-state.outputs.proceed == 'true'
         id: deploy-healthy
+        timeout-minutes: 10
         uses: ./.candidate-action
         env:
           CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
@@ -186,6 +189,7 @@ jobs:
       - name: Observe healthy fixture deployment
         if: steps.candidate-state.outputs.proceed == 'true'
         id: observe-healthy
+        timeout-minutes: 12
         env:
           CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
           CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
@@ -219,6 +223,7 @@ jobs:
       - name: Deploy healthy fixture commit with quiet env checks
         if: steps.candidate-state.outputs.proceed == 'true'
         id: deploy-env
+        timeout-minutes: 10
         uses: ./.candidate-action
         env:
           CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
@@ -236,6 +241,7 @@ jobs:
       - name: Observe healthy fixture env deployment
         if: steps.candidate-state.outputs.proceed == 'true'
         id: observe-env
+        timeout-minutes: 12
         env:
           CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
           CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
@@ -278,6 +284,7 @@ jobs:
         if: steps.candidate-state.outputs.proceed == 'true'
         id: same-commit-error
         continue-on-error: true
+        timeout-minutes: 10
         uses: ./.candidate-action
         env:
           CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
@@ -291,6 +298,7 @@ jobs:
       - name: Assert same-commit error outcome and activity
         if: steps.candidate-state.outputs.proceed == 'true'
         id: assert-same-commit-error
+        timeout-minutes: 12
         env:
           CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
           CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
@@ -312,6 +320,7 @@ jobs:
       - name: Deploy same commit with ignore policy
         if: steps.candidate-state.outputs.proceed == 'true'
         id: same-commit-ignore
+        timeout-minutes: 10
         uses: ./.candidate-action
         env:
           CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
@@ -326,6 +335,7 @@ jobs:
       - name: Observe same-commit ignore state
         if: steps.candidate-state.outputs.proceed == 'true'
         id: observe-same-commit-ignore
+        timeout-minutes: 12
         env:
           CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
           CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
@@ -346,6 +356,7 @@ jobs:
       - name: Deploy same commit with restart policy
         if: steps.candidate-state.outputs.proceed == 'true'
         id: same-commit-restart
+        timeout-minutes: 10
         uses: ./.candidate-action
         env:
           CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
@@ -360,6 +371,7 @@ jobs:
       - name: Observe same-commit restart state
         if: steps.candidate-state.outputs.proceed == 'true'
         id: observe-same-commit-restart
+        timeout-minutes: 12
         env:
           CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
           CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
@@ -381,6 +393,7 @@ jobs:
       - name: Deploy same commit with rebuild policy
         if: steps.candidate-state.outputs.proceed == 'true'
         id: same-commit-rebuild
+        timeout-minutes: 10
         uses: ./.candidate-action
         env:
           CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
@@ -395,6 +408,7 @@ jobs:
       - name: Observe same-commit rebuild state
         if: steps.candidate-state.outputs.proceed == 'true'
         id: observe-same-commit-rebuild
+        timeout-minutes: 12
         env:
           CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
           CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
@@ -440,6 +454,7 @@ jobs:
         if: steps.candidate-state.outputs.proceed == 'true'
         id: build-failure
         continue-on-error: true
+        timeout-minutes: 10
         uses: ./.candidate-action
         env:
           CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
@@ -457,6 +472,7 @@ jobs:
       - name: Assert build-failure outcome and preserved production
         if: steps.candidate-state.outputs.proceed == 'true'
         id: assert-build-failure
+        timeout-minutes: 12
         env:
           CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
           CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
@@ -489,6 +505,7 @@ jobs:
         if: steps.candidate-state.outputs.proceed == 'true'
         id: startup-failure
         continue-on-error: true
+        timeout-minutes: 10
         uses: ./.candidate-action
         env:
           CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
@@ -505,6 +522,7 @@ jobs:
       - name: Assert startup-failure outcome and preserved production
         if: steps.candidate-state.outputs.proceed == 'true'
         id: assert-startup-failure
+        timeout-minutes: 12
         env:
           CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
           CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
@@ -536,6 +554,7 @@ jobs:
       - name: Deploy recovery fixture commit
         if: steps.candidate-state.outputs.proceed == 'true'
         id: recovery
+        timeout-minutes: 10
         uses: ./.candidate-action
         env:
           CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
@@ -552,6 +571,7 @@ jobs:
       - name: Observe recovery fixture deployment
         if: steps.candidate-state.outputs.proceed == 'true'
         id: observe-recovery
+        timeout-minutes: 12
         env:
           CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
           CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
@@ -594,6 +614,7 @@ jobs:
         if: steps.candidate-state.outputs.proceed == 'true'
         id: divergent-no-force
         continue-on-error: true
+        timeout-minutes: 10
         uses: ./.candidate-action
         env:
           CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
@@ -610,6 +631,7 @@ jobs:
       - name: Assert divergent rejection outcome and preserved production
         if: steps.candidate-state.outputs.proceed == 'true'
         id: assert-divergent-no-force
+        timeout-minutes: 12
         env:
           CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
           CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
@@ -631,6 +653,7 @@ jobs:
       - name: Deploy divergent fixture commit with force
         if: steps.candidate-state.outputs.proceed == 'true'
         id: divergent-force
+        timeout-minutes: 10
         uses: ./.candidate-action
         env:
           CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
@@ -648,6 +671,7 @@ jobs:
       - name: Observe forced divergent deployment
         if: steps.candidate-state.outputs.proceed == 'true'
         id: observe-divergent-force
+        timeout-minutes: 12
         env:
           CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
           CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
@@ -678,6 +702,7 @@ jobs:
       - name: Deploy slow-build fixture commit with timeout
         if: steps.candidate-state.outputs.proceed == 'true'
         id: timeout-deploy
+        timeout-minutes: 5
         uses: ./.candidate-action
         env:
           CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
@@ -705,6 +730,7 @@ jobs:
       - name: Cancel timed-out deployment and confirm forced commit stays live
         if: always() && steps.candidate-state.outputs.proceed == 'true' && steps.timeout-deploy.outcome != 'skipped'
         id: observe-timeout-deploy
+        timeout-minutes: 12
         env:
           CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
           CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
@@ -800,6 +826,7 @@ jobs:
       - name: Delete the captured app
         if: always() && steps.candidate-state.outputs.proceed == 'true' && steps.create.outcome == 'success'
         id: delete-app
+        timeout-minutes: 15
         env:
           CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
           CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}

--- a/docs/e2e-operations.md
+++ b/docs/e2e-operations.md
@@ -66,6 +66,12 @@ Teardown always targets the captured app ID.
 It loops until no deployment is still active, waiting for each latest deployment to reach `WIP`, cancelling it, then deleting the app by exact ID and checking that the app no longer appears in Clever Cloud.
 If cleanup fails, the workflow reports the exact app name and ID so you can remove it by hand.
 
+The suite job is capped at 30 minutes, and its long-running steps carry their own caps, so a hung step fails on its own and teardown still runs on a normal budget rather than a cancellation grace window.
+That is the point of the step caps, protecting cleanup.
+Teardown's own step cap is 15 minutes, and the cancel-and-settle loop inside `deleteApplication` has its own 10-minute budget (`DEFAULT_SETTLE_TIMEOUT_MS` in `src/e2e/clever-client.ts`), after which it gives up and reports.
+A hang arriving late in the run can still push the job into its 30-minute cap during teardown, so a run that shows as cancelled by timeout rather than failed may never have written the app name and ID report.
+Skip straight to the manual cleanup commands below in that case.
+
 For manual recovery, first download the failure evidence artifact if one exists.
 If `clever cancel-deploy` reports that the latest deployment is not in `WIP`, wait for that deployment to reach `WIP` and retry.
 Then use the reported app ID with Clever Tools from a trusted shell:

--- a/src/e2eWorkflowInvariants.test.ts
+++ b/src/e2eWorkflowInvariants.test.ts
@@ -12,6 +12,7 @@ type Step = {
   run?: string
   env?: Record<string, string>
   with?: Record<string, unknown>
+  'timeout-minutes'?: number
 }
 
 type Concurrency = {
@@ -313,7 +314,7 @@ describe('shared workflow policies', () => {
         }
         expect(job['timeout-minutes'], `${file} ${jobId}`).toBeGreaterThan(0)
         expect(job['timeout-minutes'], `${file} ${jobId}`).toBeLessThanOrEqual(
-          40
+          30
         )
       }
     }
@@ -866,5 +867,26 @@ describe('e2e-reusable', () => {
       "import { DEPLOYMENT_TIMEOUT_MESSAGE } from '../../deployment.ts'"
     )
     expect(timeoutScript).toContain('DEPLOYMENT_TIMEOUT_MESSAGE')
+  })
+
+  test('bounds every candidate action invocation well under the job timeout', () => {
+    const candidateActionSteps = suiteSteps.filter(
+      step => step.uses === './.candidate-action'
+    )
+    expect(candidateActionSteps.length).toBeGreaterThan(0)
+    for (const step of candidateActionSteps) {
+      const limit = step.id === 'timeout-deploy' ? 5 : 10
+      expect(step['timeout-minutes'], step.id).toBeGreaterThan(0)
+      expect(step['timeout-minutes'], step.id).toBeLessThanOrEqual(limit)
+    }
+  })
+
+  test('lets the timeout-deploy action exit on its own before the step cap does', () => {
+    const timeoutDeploy = onlyStep(
+      suiteSteps,
+      step => step.id === 'timeout-deploy'
+    )
+    expect(timeoutDeploy.with?.['timeout']).toBe(60)
+    expect(timeoutDeploy['timeout-minutes']).toBe(5)
   })
 })


### PR DESCRIPTION
Follow-up to #277, which added job-level timeouts. This adds the step-level ones, and lowers the suite cap from 40 to 30.

The job cap alone is a poor guard for cleanup. When a job hits `timeout-minutes` GitHub cancels it, and `Delete the captured app` is gated `if: always()` so it fires, but teardown is not quick: it loops over active deployments, waits for each to settle on a 10-minute budget, cancels, then deletes and verifies. A cancellation grace window is not 10 minutes, so the cap fires exactly when there is least time left to clean up, and a live app can survive.

Step-level caps change the shape. A hung step now fails on its own, the later scenarios skip on their success gate, and teardown runs with a normal budget instead of a grace window. The job cap stays as a backstop.

The numbers come from the recorded runs: the suite job's worst observed is 17.8 minutes across 26 runs, best successful 7.8. Deploy steps get 10 minutes, the twelve polling observers get 12 (they carry internal settle budgets up to 10 minutes, so a tighter cap would kill them mid-poll), teardown gets 15, and the two `pnpm install` steps get 5.

`timeout-deploy` gets 5 rather than 10, and that one is load-bearing. Its action input is `timeout: 60` against a 3-minute build delay, and the scenario exists to prove the action exits 0 on its own timeout. The step cap has to stay above 60 seconds so the action's timeout fires first and GitHub's never does. A test pins both literals so neither can drift into the other.

One consequence worth stating: a 10-minute step cap makes the action's own `timeout: 1200` input unreachable on the other eleven steps, since GitHub kills the step first. That is the intended trade, but it leaves the two numbers incoherent, and lowering those inputs to match would be a reasonable follow-up.

Residual case this does not cover: a hang arriving late in the run can still push past the 30-minute cap during teardown. Covering every case needs roughly 45. 30 was chosen deliberately to fail fast.
