### PR TITLE
doc: correct nine README claims against the code

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,9 +150,9 @@ A `setEnv` line that is not valid `KEY=value` (bad characters in the key or
 broken quoting) is skipped. The action logs a warning and continues without
 that variable.
 
-If the deployment fails, the environment variables will still have been
-updated. This could be a problem if your app restarts or scales up, as
-the new instance would use the new variable.
+If the deployment fails, or setting the variables fails partway through, the
+ones already applied will still be live. This could be a problem if your app
+restarts or scales up, as the new instance would use the new variable.
 
 In the future, we might include a way to rollback environment variables
 set by this action if deployment fails.
@@ -192,7 +192,7 @@ fails the step.
 
 > Support: introduced in v1.2.0
 
-Clever Cloud uses a Git remote to perform deploys. By default, if the commit you want to deploy is not a fast-forward from the commit currently deployed, the deploy will be rejected. You can pass `force: true` to force the deploy anyway:
+Clever Cloud uses a Git remote to perform deploys. By default, if the commit you want to deploy is not a fast-forward from the last commit pushed to that remote, the deploy will be rejected. You can pass `force: true` to force the deploy anyway:
 
 <!-- x-release-please-start-version -->
 ```yml
@@ -247,7 +247,7 @@ monorepo, the whole repository is still sent.
 When the local and remote commits are identical, you can control what happens using the `sameCommitPolicy` option. Possible values are:
 
 - `error` (default): Fail the deployment
-- `ignore`: Skip the deployment silently
+- `ignore`: Skip the deployment without failing
 - `restart`: Redeploy the same commit, reusing the build cache
 - `rebuild`: Redeploy the same commit without the build cache
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ If you try deploying it with this Github action, you will get the
 following message in your logs: `[ERROR] HTTP Error: 401 Authorization
 Required`.
 
-Currently (early 2023), the only workaround is to create a new
+The only workaround is to create a new
 application on Clever Cloud, that deploys "_from a local repository_",
 then remove the Clever Cloud webhook that has been created on your
 Github repository.
@@ -36,7 +36,7 @@ In your workflow file:
 steps:
   # This action requires an unshallow working copy,
   # so the following prerequisites are necessary:
-  - uses: actions/checkout@v3
+  - uses: actions/checkout@v7
     with:
       fetch-depth: 0
 
@@ -85,6 +85,8 @@ deploy to another application, you can pass its ID:
     CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
 ```
 <!-- x-release-please-end -->
+
+If you set both `alias` and `appID`, `appID` takes precedence and `alias` is ignored.
 
 Application IDs can be found in the [Clever Cloud console](https://console.clever-cloud.com/),
 at the top-right corner of any page for a given app, or in the Information tab.
@@ -144,6 +146,10 @@ to let the new deployment use them.
 Multi-line environment variable values (eg: SSH keys, X.509 certificates) are
 currently not supported (due to splitting on newline), but contributions are welcome.
 
+A `setEnv` line that is not valid `KEY=value` (bad characters in the key, broken
+quoting, or a key of `__proto__`) is skipped. The action logs a warning and
+continues without that variable.
+
 If the deployment fails, the environment variables will still have been
 updated. This could be a problem if your app restarts or scales up, as
 the new instance would use the new variable.
@@ -172,6 +178,14 @@ regardless of the deployment status:
     CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
 ```
 <!-- x-release-please-end -->
+
+When the timeout is reached, the action stops waiting and moves on, but the
+deployment on Clever Cloud keeps running. Nothing tells Clever Cloud to
+cancel it.
+
+`timeout` must be a non-negative integer number of seconds, up to 86400
+(24 hours). Set it to `0` to disable the timeout. Any other value fails
+the step.
 
 ## Force deployement
 
@@ -249,7 +263,7 @@ When the local and remote commits are identical, you can control what happens us
 
 ## Logs
 
-> Support: introduced in v1.3.1
+> Support: introduced in v1.3.0
 
 You can write the deployment logs to a file for archiving:
 
@@ -262,7 +276,7 @@ You can write the deployment logs to a file for archiving:
     CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
     CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
 # Optional: save the file as an artifact
-- uses: actions/upload-artifact@v2
+- uses: actions/upload-artifact@v4
   name: Upload deployment logs
   with:
     name: clever-cloud-deploy.log
@@ -285,6 +299,9 @@ disable it from printing onto the console, using the `quiet` option:
 ```
 <!-- x-release-please-end -->
 
+`quiet` only silences the console. If you also set `logFile`, the file
+still gets the full deployment output.
+
 ### Annotations
 
 The action will detect the [workflow commands](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-a-notice-message)
@@ -301,13 +318,13 @@ To specify the version of the action to use:
 
 - `uses: 47ng/actions-clever-cloud@v2.1.5`: latest stable version <!-- x-release-please-version -->
 - `uses: 47ng/actions-clever-cloud@f496297399b2351f4459d10f556e1c4eff2566b7`: pinned to a specific Git SHA-1 (check out the [releases](https://github.com/47ng/actions-clever-cloud/releases))
-- `uses: docker://ghcr.io/47ng/actions-clever-cloud:latest`: latest code from master (not recommended, as it may break: hic sunt dracones.)
+- `uses: docker://ghcr.io/47ng/actions-clever-cloud:latest`: tracks the newest released version (moved there right after each release, not from an ordinary push to master)
 
 > **Note**: `uses: 47ng/actions-clever-cloud@master` will not use the latest code on the `master` branch,
 > because the action manifest is pinned on the latest relase for performance reasons (it saves
 > rebuilding the Docker image when consuming the action).
 >
-> If you wish to test unreleased features, go through Docker directly.
+> To test unreleased features, pin a `git-<sha>` preview image built for a pull request.
 
 > **Note**: as of 2023-03-24, Docker images have been copied from Docker Hub
 > (`47ng/actions-clever-cloud`) to GitHub Container Registry (`ghcr.io/47ng/actions-clever-cloud`),

--- a/README.md
+++ b/README.md
@@ -146,9 +146,9 @@ to let the new deployment use them.
 Multi-line environment variable values (eg: SSH keys, X.509 certificates) are
 currently not supported (due to splitting on newline), but contributions are welcome.
 
-A `setEnv` line that is not valid `KEY=value` (bad characters in the key, broken
-quoting, or a key of `__proto__`) is skipped. The action logs a warning and
-continues without that variable.
+A `setEnv` line that is not valid `KEY=value` (bad characters in the key or
+broken quoting) is skipped. The action logs a warning and continues without
+that variable.
 
 If the deployment fails, the environment variables will still have been
 updated. This could be a problem if your app restarts or scales up, as
@@ -184,8 +184,9 @@ deployment on Clever Cloud keeps running. Nothing tells Clever Cloud to
 cancel it.
 
 `timeout` must be a non-negative integer number of seconds, up to 86400
-(24 hours). Set it to `0` to disable the timeout. Any other value fails
-the step.
+(24 hours). No timeout is already the default; `0` is only useful when the
+value comes from an expression that may evaluate to zero. Any other value
+fails the step.
 
 ## Force deployement
 
@@ -247,8 +248,8 @@ When the local and remote commits are identical, you can control what happens us
 
 - `error` (default): Fail the deployment
 - `ignore`: Skip the deployment silently
-- `restart`: Restart the application without redeploying
-- `rebuild`: Rebuild and redeploy the application
+- `restart`: Redeploy the same commit, reusing the build cache
+- `rebuild`: Redeploy the same commit without the build cache
 
 <!-- x-release-please-start-version -->
 ```yml


### PR DESCRIPTION
An audit traced every factual claim in the README back to the code. Nine came back wrong, stale, or missing something that bites.

One claim was flatly wrong. `:latest` was described as "latest code from master". The `latest` job in `main.yml` is gated on `release_created == 'true'` and moves the tag to a released digest, and `move-latest.sh` refuses to move it backwards, so `:latest` tracks the newest release. The advice underneath it, to test unreleased features through Docker, was misleading for the same reason: that gets you released code. Pinning a `git-<sha>` preview image is the way to do it.

Two examples fail if copied today. `actions/upload-artifact@v2` is rejected outright by GitHub Actions, and `actions/checkout@v3` is several majors behind what this repo pins. Both now match the majors used in `.github/workflows`.

Quiet mode and `logFile` shipped in v1.3.0, not v1.3.1.

The rest are omissions where the code does something quietly that the docs never mention:

- Setting both `alias` and `appID` is not a choice. `appID` wins and `alias` is ignored.
- A malformed `setEnv` line is skipped with a warning and the deploy continues, so a typo means the app comes up missing a variable.
- `quiet` silences the console only. `logFile` still receives the full output, which matters because that section is about hiding secrets.
- A timeout stops the action waiting. It does not cancel the deployment, which keeps running on Clever Cloud.
- `timeout` accepts a non-negative integer up to 86400, `0` disables it, and anything else fails the step outright, which is the opposite of the graceful behaviour described in the same section.

Also dropped a stale "Currently (early 2023)" qualifier.
