### PR TITLE
doc: correct the cancel-deploy recovery guidance

### DIFF
--- a/docs/e2e-operations.md
+++ b/docs/e2e-operations.md
@@ -73,7 +73,8 @@ A hang arriving late in the run can still push the job into its 30-minute cap du
 Skip straight to the manual cleanup commands below in that case.
 
 For manual recovery, first download the failure evidence artifact if one exists.
-If `clever cancel-deploy` reports that the latest deployment is not in `WIP`, wait for that deployment to reach `WIP` and retry.
+`clever cancel-deploy` reports `There is no ongoing deployment for this application` both when a deployment is genuinely in flight but not yet in a cancellable state, and when there is nothing left to cancel at all, including right after a cancellation has already replaced the deploy row.
+Retry briefly if you expect a deployment to still be running, and otherwise go straight to the delete command below.
 Then use the reported app ID with Clever Tools from a trusted shell:
 
 ```bash


### PR DESCRIPTION
The manual recovery steps told an operator to wait for the deployment to reach `WIP` and retry. The CLI never says anything about `WIP`. It throws one generic message, `There is no ongoing deployment for this application`, when any of three conditions holds: no deployment at all, the latest activity is not a `DEPLOY`, or the deploy is not in `WIP`.

Waiting only helps for the third. The second one is the trap, and this suite hits it routinely: Clever removes the `DEPLOY` row of a deployment cancelled mid-build and replaces it with a `CANCEL` row under a new uuid, which is exactly the state the timeout scenario leaves behind. An operator following the old instruction there waits for a `WIP` that is never coming.

Now says what the CLI actually reports, what it covers, and when to stop waiting and go to the delete command.
