### PR TITLE
doc: correct the quiet security claim and three behaviour gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ Application IDs can be found in the [Clever Cloud console](https://console.cleve
 at the top-right corner of any page for a given app, or in the Information tab.
 They look like `app_{uuidv4}`.
 
+The first deploy with a given `appID` links it via `clever link`, which writes
+a `.clever.json` file into the working tree (or `deployPath`, if you set one).
+
 ## Authentication
 
 You will need to pass a token and a secret for authentication, via the
@@ -182,6 +185,9 @@ regardless of the deployment status:
 When the timeout is reached, the action stops waiting and moves on, but the
 deployment on Clever Cloud keeps running. Nothing tells Clever Cloud to
 cancel it.
+
+If the timeout fires during the push itself, the process is killed, the
+step still succeeds, and nothing was ever deployed.
 
 `timeout` must be a non-negative integer number of seconds, up to 86400
 (24 hours). No timeout is already the default; `0` is only useful when the
@@ -302,6 +308,10 @@ disable it from printing onto the console, using the `quiet` option:
 
 `quiet` only silences the console. If you also set `logFile`, the file
 still gets the full deployment output.
+
+The timeout message is an exception: it only reaches `logFile` when `quiet`
+is set too. Without `quiet`, a timed-out deployment's log file just stops,
+with nothing explaining why.
 
 ### Annotations
 

--- a/action.yml
+++ b/action.yml
@@ -47,8 +47,8 @@ inputs:
     required: false
     default: 'false'
     description: |
-      Don't print deployment output to the console. Use this in case your deployment
-      may reveal secrets or PII.
+      Don't print deployment output to the console. This does not affect
+      logFile, which still receives the raw output, secrets and PII included.
   sameCommitPolicy:
     required: false
     description: |


### PR DESCRIPTION
Stacked on #282, which also edits `README.md`. Merge that one first and GitHub will retarget this to master.

Found by an audit that traced every input in `action.yml` through the action and into `clever-tools`, rather than checking that arguments reach the CLI. Four things came back.

The one worth the PR on its own: `action.yml` told you to reach for `quiet` when your deployment may reveal secrets or PII. `src/output.ts` gates the console with `if (!quiet)` and has a separate, ungated `if (logFile)` that always receives the raw stream, and `src/output.test.ts` pins exactly that. Secret masking through `core.setSecret` only redacts the runner's own console capture, never bytes on disk. The README teaches `logFile` with an `upload-artifact` example immediately before the `quiet` section, so following the docs end to end published unredacted output as a downloadable artifact. The description now says what `quiet` does and that `logFile` is unaffected.

Three smaller gaps, all in the README:

A timed-out run leaves no trace in the log file unless `quiet` is set too. `src/deployment.ts` writes the timeout message to the deploy log only under `if (config.quiet && config.logFile)`, so archiving with `logFile` alone gives you a file that stops with no explanation.

A short enough timeout kills the push itself. `src/clever.ts` races the whole child process, and the push happens before the deployment watch, so the step still succeeds while nothing was deployed at all.

The first deploy with a given `appID` runs `clever link`, which writes a `.clever.json` into the working tree, or into `deployPath` when set.

`runs.image` is untouched.
