### PR TITLE
feat: expose deployment timeout output

### DIFF
--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -725,7 +725,7 @@ jobs:
         id: assert-timeout-deploy
         env:
           ACTION_OUTCOME: ${{ steps.timeout-deploy.outcome }}
-          TIMED_OUT: ${{ steps.timeout-deploy.outputs.timedOut }}
+          ACTION_TIMED_OUT: ${{ steps.timeout-deploy.outputs.timedOut }}
           LOG_PATH: ${{ github.workspace }}/.e2e-artifacts/candidate-action/012-timeout.log
           TRUSTED_WORKFLOW_DIR: ${{ runner.temp }}/trusted-workflow
         run: node "$TRUSTED_WORKFLOW_DIR"/src/e2e/scripts/assert-timeout-contract.ts

--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -528,6 +528,7 @@ jobs:
           CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
           APP_ID: ${{ steps.create.outputs.app_id }}
           ACTION_OUTCOME: ${{ steps.startup-failure.outcome }}
+          ACTION_TIMED_OUT: ${{ steps.startup-failure.outputs.timedOut }}
           EXPECTED_COMMIT_ID: ${{ steps.startup-failure-commit.outputs.commit }}
           STATE_PATH: ${{ github.workspace }}/.e2e-state/failed-deploy-state.json
           LOG_PATH: ${{ github.workspace }}/.e2e-artifacts/candidate-action/008-startup-failure.log

--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -577,6 +577,7 @@ jobs:
           CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
           APP_ID: ${{ steps.create.outputs.app_id }}
           EXPECTED_COMMIT_ID: ${{ steps.recovery-commit.outputs.commit }}
+          ACTION_TIMED_OUT: ${{ steps.recovery.outputs.timedOut }}
         run: node .candidate-source/src/e2e/scripts/observe-recovery-deployment.ts
 
       - name: Capture force baseline state
@@ -723,6 +724,7 @@ jobs:
         id: assert-timeout-deploy
         env:
           ACTION_OUTCOME: ${{ steps.timeout-deploy.outcome }}
+          TIMED_OUT: ${{ steps.timeout-deploy.outputs.timedOut }}
           LOG_PATH: ${{ github.workspace }}/.e2e-artifacts/candidate-action/012-timeout.log
           TRUSTED_WORKFLOW_DIR: ${{ runner.temp }}/trusted-workflow
         run: node "$TRUSTED_WORKFLOW_DIR"/src/e2e/scripts/assert-timeout-contract.ts

--- a/README.md
+++ b/README.md
@@ -189,6 +189,15 @@ cancel it.
 If the timeout fires during the push itself, the process is killed, the
 step still succeeds, and nothing was ever deployed.
 
+`timeout` must be a non-negative integer number of seconds, up to 86400
+(24 hours). No timeout is already the default; `0` is only useful when the
+value comes from an expression that may evaluate to zero. Any other value
+fails the step.
+
+### Reading timeout status
+
+> Support: introduced in v2.2.0
+
 Give the action step an ID to check whether it timed out:
 
 <!-- x-release-please-start-version -->
@@ -211,11 +220,6 @@ Give the action step an ID to check whether it timed out:
 The `timedOut` output is `true` when the action reaches the timeout. It stays
 `false` when the action does not reach the timeout. This includes deployment
 failures.
-
-`timeout` must be a non-negative integer number of seconds, up to 86400
-(24 hours). No timeout is already the default; `0` is only useful when the
-value comes from an expression that may evaluate to zero. Any other value
-fails the step.
 
 ## Force deployement
 

--- a/README.md
+++ b/README.md
@@ -189,6 +189,28 @@ cancel it.
 If the timeout fires during the push itself, the process is killed, the
 step still succeeds, and nothing was ever deployed.
 
+Give the action step an ID to check whether it timed out:
+
+<!-- x-release-please-start-version -->
+```yml
+- name: Deploy
+  id: deploy
+  uses: 47ng/actions-clever-cloud@v2.1.5
+  with:
+    timeout: 1800
+  env:
+    CLEVER_TOKEN: ${{ secrets.CLEVER_TOKEN }}
+    CLEVER_SECRET: ${{ secrets.CLEVER_SECRET }}
+
+- name: Handle a timed-out deployment
+  if: steps.deploy.outputs.timedOut == 'true'
+  run: echo "The deployment is still running on Clever Cloud"
+```
+<!-- x-release-please-end -->
+
+The `timedOut` output is `true` when the action reaches the timeout. It is
+`false` when the deployment finishes before the timeout.
+
 `timeout` must be a non-negative integer number of seconds, up to 86400
 (24 hours). No timeout is already the default; `0` is only useful when the
 value comes from an expression that may evaluate to zero. Any other value

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Give the action step an ID to check whether it timed out:
 
 - name: Handle a timed-out deployment
   if: steps.deploy.outputs.timedOut == 'true'
-  run: echo "The deployment is still running on Clever Cloud"
+  run: echo "The action stopped waiting for the deployment"
 ```
 <!-- x-release-please-end -->
 

--- a/README.md
+++ b/README.md
@@ -208,8 +208,9 @@ Give the action step an ID to check whether it timed out:
 ```
 <!-- x-release-please-end -->
 
-The `timedOut` output is `true` when the action reaches the timeout. It is
-`false` when the deployment finishes before the timeout.
+The `timedOut` output is `true` when the action reaches the timeout. It stays
+`false` when the action does not reach the timeout. This includes deployment
+failures.
 
 `timeout` must be a non-negative integer number of seconds, up to 86400
 (24 hours). No timeout is already the default; `0` is only useful when the

--- a/action.yml
+++ b/action.yml
@@ -55,6 +55,9 @@ inputs:
       What to do when local and remote commit are identical.
       Possible values: error, ignore, restart, rebuild.
       If not set, the Clever Cloud CLI default (error) will be used.
+outputs:
+  timedOut:
+    description: Whether the deployment wait reached the configured timeout.
 runs:
   using: docker
   image: docker://ghcr.io/47ng/actions-clever-cloud:2.1.5 # x-release-please-version

--- a/src/clever.test.ts
+++ b/src/clever.test.ts
@@ -94,6 +94,7 @@ function fakeHost(): Host {
     debug: vi.fn(),
     warning: vi.fn(),
     maskSecret: vi.fn(),
+    setOutput: vi.fn(),
     fail: vi.fn()
   }
 }

--- a/src/deployment.test.ts
+++ b/src/deployment.test.ts
@@ -61,6 +61,7 @@ function fakeHost(): Host {
     debug: vi.fn(),
     warning: vi.fn(),
     maskSecret: vi.fn(),
+    setOutput: vi.fn(),
     fail: vi.fn()
   }
 }
@@ -249,12 +250,14 @@ test('a timed-out deployment moves on without failing', async () => {
   const deps = makeDeps({ outcome: 'timed-out' })
   await expect(deploy(config({ timeout: 1800 }), deps)).resolves.toBeUndefined()
   expect(deps.host.info).toHaveBeenCalledWith(DEPLOYMENT_TIMEOUT_MESSAGE)
+  expect(deps.host.setOutput).toHaveBeenCalledWith('timedOut', true)
 })
 
 test('a completed deployment does not log the timeout message', async () => {
   const deps = makeDeps()
   await deploy(config(), deps)
   expect(deps.host.info).not.toHaveBeenCalledWith(DEPLOYMENT_TIMEOUT_MESSAGE)
+  expect(deps.host.setOutput).toHaveBeenCalledWith('timedOut', false)
 })
 
 test('a quiet timed-out deployment writes the timeout message to the deploy log', async () => {

--- a/src/deployment.test.ts
+++ b/src/deployment.test.ts
@@ -257,7 +257,6 @@ test('a completed deployment does not log the timeout message', async () => {
   const deps = makeDeps()
   await deploy(config(), deps)
   expect(deps.host.info).not.toHaveBeenCalledWith(DEPLOYMENT_TIMEOUT_MESSAGE)
-  expect(deps.host.setOutput).toHaveBeenCalledWith('timedOut', false)
 })
 
 test('a quiet timed-out deployment writes the timeout message to the deploy log', async () => {

--- a/src/deployment.ts
+++ b/src/deployment.ts
@@ -32,6 +32,7 @@ export async function deploy(
     sameCommitPolicy: config.sameCommitPolicy,
     timeoutSeconds: config.timeout
   })
+  host.setOutput('timedOut', outcome === 'timed-out')
   if (outcome === 'timed-out') {
     // When quiet suppresses the console pipeline, the log file is the only
     // place the timeout can be observed; the live e2e suite asserts it there.

--- a/src/deployment.ts
+++ b/src/deployment.ts
@@ -32,8 +32,8 @@ export async function deploy(
     sameCommitPolicy: config.sameCommitPolicy,
     timeoutSeconds: config.timeout
   })
-  host.setOutput('timedOut', outcome === 'timed-out')
   if (outcome === 'timed-out') {
+    host.setOutput('timedOut', true)
     // When quiet suppresses the console pipeline, the log file is the only
     // place the timeout can be observed; the live e2e suite asserts it there.
     if (config.quiet && config.logFile) {

--- a/src/e2e/scripts/assert-startup-failure.ts
+++ b/src/e2e/scripts/assert-startup-failure.ts
@@ -17,6 +17,7 @@ import {
 
 const appId = process.env.APP_ID
 const actionOutcome = process.env.ACTION_OUTCOME
+const actionTimedOut = process.env.ACTION_TIMED_OUT
 const expectedCommitID = process.env.EXPECTED_COMMIT_ID
 const statePath = process.env.STATE_PATH
 const logPath = process.env.LOG_PATH
@@ -26,6 +27,7 @@ const cleverCLI = resolveCleverCLI()
 if (
   !appId ||
   !actionOutcome ||
+  !actionTimedOut ||
   !expectedCommitID ||
   !statePath ||
   !logPath ||
@@ -36,6 +38,10 @@ if (
 
 if (actionOutcome !== 'failure') {
   throw new Error('Expected startup-failure deployment to fail')
+}
+
+if (actionTimedOut !== 'false') {
+  throw new Error('Expected failed deployment action to set timedOut=false')
 }
 
 const previousState = parseBaselineState(

--- a/src/e2e/scripts/assert-timeout-contract.ts
+++ b/src/e2e/scripts/assert-timeout-contract.ts
@@ -2,14 +2,19 @@ import { readFile } from 'node:fs/promises'
 import { DEPLOYMENT_TIMEOUT_MESSAGE } from '../../deployment.ts'
 
 const actionOutcome = process.env.ACTION_OUTCOME
+const timedOut = process.env.TIMED_OUT
 const logPath = process.env.LOG_PATH
 
-if (!actionOutcome || !logPath) {
+if (!actionOutcome || !timedOut || !logPath) {
   throw new Error('Missing timeout assertion inputs')
 }
 
 if (actionOutcome !== 'success') {
   throw new Error('Expected timed-out deployment action to succeed')
+}
+
+if (timedOut !== 'true') {
+  throw new Error('Expected timed-out deployment action to set timedOut=true')
 }
 
 const logContent = await readFile(logPath, 'utf8')

--- a/src/e2e/scripts/assert-timeout-contract.ts
+++ b/src/e2e/scripts/assert-timeout-contract.ts
@@ -2,7 +2,7 @@ import { readFile } from 'node:fs/promises'
 import { DEPLOYMENT_TIMEOUT_MESSAGE } from '../../deployment.ts'
 
 const actionOutcome = process.env.ACTION_OUTCOME
-const timedOut = process.env.TIMED_OUT
+const timedOut = process.env.ACTION_TIMED_OUT
 const logPath = process.env.LOG_PATH
 
 if (!actionOutcome || !timedOut || !logPath) {

--- a/src/e2e/scripts/observe-recovery-deployment.ts
+++ b/src/e2e/scripts/observe-recovery-deployment.ts
@@ -9,11 +9,16 @@ import {
 
 const appId = process.env.APP_ID
 const expectedCommitID = process.env.EXPECTED_COMMIT_ID
+const actionTimedOut = process.env.ACTION_TIMED_OUT
 const githubOutput = process.env.GITHUB_OUTPUT
 const cleverCLI = resolveCleverCLI()
 
-if (!appId || !expectedCommitID || !githubOutput) {
+if (!appId || !expectedCommitID || !actionTimedOut || !githubOutput) {
   throw new Error('Missing recovery deployment observation inputs')
+}
+
+if (actionTimedOut !== 'false') {
+  throw new Error('Expected completed deployment action to set timedOut=false')
 }
 
 const controller = createCleverController({

--- a/src/e2eWorkflowInvariants.test.ts
+++ b/src/e2eWorkflowInvariants.test.ts
@@ -851,6 +851,21 @@ describe('e2e-reusable', () => {
     )
   })
 
+  test('checks that a completed deployment reports timedOut=false', () => {
+    const recoveryObserver = onlyStep(
+      suiteSteps,
+      step =>
+        step.run ===
+        'node .candidate-source/src/e2e/scripts/observe-recovery-deployment.ts'
+    )
+    expect(recoveryObserver.env?.['ACTION_TIMED_OUT']).toBe(
+      '${{ steps.recovery.outputs.timedOut }}'
+    )
+    const recoveryScript = scriptSourceOf('observe-recovery-deployment.ts')
+    expect(recoveryScript).toContain('process.env.ACTION_TIMED_OUT')
+    expect(recoveryScript).toContain("actionTimedOut !== 'false'")
+  })
+
   test('checks the timeout contract from the trusted workflow copy, against the shared message', () => {
     const timeoutAssertion = onlyStep(
       suiteSteps,
@@ -860,6 +875,9 @@ describe('e2e-reusable', () => {
     expect(timeoutAssertion.run).toBe(
       'node "$TRUSTED_WORKFLOW_DIR"/src/e2e/scripts/assert-timeout-contract.ts'
     )
+    expect(timeoutAssertion.env?.['TIMED_OUT']).toBe(
+      '${{ steps.timeout-deploy.outputs.timedOut }}'
+    )
     const timeoutScript = scriptSourceOf('assert-timeout-contract.ts')
     // TypeScript guarantees the constant's value; these only guarantee the
     // script still performs the check, against the single definition of it.
@@ -867,6 +885,8 @@ describe('e2e-reusable', () => {
       "import { DEPLOYMENT_TIMEOUT_MESSAGE } from '../../deployment.ts'"
     )
     expect(timeoutScript).toContain('DEPLOYMENT_TIMEOUT_MESSAGE')
+    expect(timeoutScript).toContain('process.env.TIMED_OUT')
+    expect(timeoutScript).toContain("timedOut !== 'true'")
   })
 
   test('bounds every candidate action invocation well under the job timeout', () => {

--- a/src/e2eWorkflowInvariants.test.ts
+++ b/src/e2eWorkflowInvariants.test.ts
@@ -851,7 +851,7 @@ describe('e2e-reusable', () => {
     )
   })
 
-  test('checks that a completed deployment reports timedOut=false', () => {
+  test('checks that non-timeout deployments report timedOut=false', () => {
     const recoveryObserver = onlyStep(
       suiteSteps,
       step =>
@@ -864,6 +864,17 @@ describe('e2e-reusable', () => {
     const recoveryScript = scriptSourceOf('observe-recovery-deployment.ts')
     expect(recoveryScript).toContain('process.env.ACTION_TIMED_OUT')
     expect(recoveryScript).toContain("actionTimedOut !== 'false'")
+
+    const startupFailureAssertion = onlyStep(
+      suiteSteps,
+      step => step.id === 'assert-startup-failure'
+    )
+    expect(startupFailureAssertion.env?.['ACTION_TIMED_OUT']).toBe(
+      '${{ steps.startup-failure.outputs.timedOut }}'
+    )
+    const startupFailureScript = scriptSourceOf('assert-startup-failure.ts')
+    expect(startupFailureScript).toContain('process.env.ACTION_TIMED_OUT')
+    expect(startupFailureScript).toContain("actionTimedOut !== 'false'")
   })
 
   test('checks the timeout contract from the trusted workflow copy, against the shared message', () => {

--- a/src/e2eWorkflowInvariants.test.ts
+++ b/src/e2eWorkflowInvariants.test.ts
@@ -886,7 +886,7 @@ describe('e2e-reusable', () => {
     expect(timeoutAssertion.run).toBe(
       'node "$TRUSTED_WORKFLOW_DIR"/src/e2e/scripts/assert-timeout-contract.ts'
     )
-    expect(timeoutAssertion.env?.['TIMED_OUT']).toBe(
+    expect(timeoutAssertion.env?.['ACTION_TIMED_OUT']).toBe(
       '${{ steps.timeout-deploy.outputs.timedOut }}'
     )
     const timeoutScript = scriptSourceOf('assert-timeout-contract.ts')
@@ -896,7 +896,7 @@ describe('e2e-reusable', () => {
       "import { DEPLOYMENT_TIMEOUT_MESSAGE } from '../../deployment.ts'"
     )
     expect(timeoutScript).toContain('DEPLOYMENT_TIMEOUT_MESSAGE')
-    expect(timeoutScript).toContain('process.env.TIMED_OUT')
+    expect(timeoutScript).toContain('process.env.ACTION_TIMED_OUT')
     expect(timeoutScript).toContain("timedOut !== 'true'")
   })
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -5,6 +5,7 @@ export type Host = {
   debug(message: string): void
   warning(message: string): void
   maskSecret(value: string): void
+  setOutput(name: string, value: unknown): void
   fail(message: string): void
 }
 
@@ -14,6 +15,7 @@ export function gitHubHost(): Host {
     debug: core.debug,
     warning: core.warning,
     maskSecret: core.setSecret,
+    setOutput: core.setOutput,
     fail: core.setFailed
   }
 }

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -24,6 +24,7 @@ const host: Host = {
   debug: vi.fn(),
   warning: vi.fn(),
   maskSecret: vi.fn(),
+  setOutput: vi.fn(),
   fail: vi.fn()
 }
 

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -59,6 +59,7 @@ test('a successful deployment does not fail the workflow', async () => {
   await main()
   expect(host.fail).not.toHaveBeenCalled()
   expect(deploy).toHaveBeenCalledOnce()
+  expect(host.setOutput).toHaveBeenCalledWith('timedOut', false)
 })
 
 test('the client is wired with the parsed CLI path, the log stream and the host', async () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import { createDeployLog, type DeployLog } from './output.ts'
 
 export async function main(): Promise<void> {
   const host = gitHubHost()
+  host.setOutput('timedOut', false)
   let log: DeployLog | undefined
   try {
     await fixGitDubiousOwnership()


### PR DESCRIPTION
Consumers could not tell a finished deployment from one where the action stopped waiting. This lets later steps handle timed-out deployments without parsing logs.

Tests cover both output values in unit and live E2E paths.