### PR TITLE
ci: clarify E2E deployment job name

### DIFF
--- a/.github/workflows/e2e-manual.yml
+++ b/.github/workflows/e2e-manual.yml
@@ -73,8 +73,8 @@ jobs:
           EXPECTED_SOURCE_REPOSITORY: ${{ needs.resolve.outputs.candidate_source_repository }}
         run: node src/e2e/scripts/verify-image.ts
 
-  create-and-delete:
-    name: Create and delete app
+  e2e-deployment-test:
+    name: E2E Deployment Test
     needs: [resolve, candidate]
     uses: ./.github/workflows/e2e-reusable.yml
     permissions:

--- a/.github/workflows/e2e-release-please.yml
+++ b/.github/workflows/e2e-release-please.yml
@@ -194,8 +194,8 @@ jobs:
           TRUSTED_E2E_DIR: ${{ runner.temp }}/trusted-e2e
         run: node "$TRUSTED_E2E_DIR"/scripts/verify-image.ts
 
-  create-and-delete:
-    name: Create and delete app
+  e2e-deployment-test:
+    name: E2E Deployment Test
     if: needs.current-state.outputs.proceed == 'true'
     needs: [resolve, current-state, candidate]
     uses: ./.github/workflows/e2e-reusable.yml

--- a/.github/workflows/e2e-reusable.yml
+++ b/.github/workflows/e2e-reusable.yml
@@ -32,8 +32,8 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  create-and-delete:
-    name: Create and delete app
+  e2e-deployment-test:
+    name: E2E Deployment Test
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/src/e2e/scenario-catalogue.test.ts
+++ b/src/e2e/scenario-catalogue.test.ts
@@ -29,7 +29,7 @@ const workflowPath = fileURLToPath(
 
 const workflow: Workflow = parse(readFileSync(workflowPath, 'utf8'))
 
-const suiteSteps: Step[] = workflow.jobs['create-and-delete']?.steps ?? []
+const suiteSteps: Step[] = workflow.jobs['e2e-deployment-test']?.steps ?? []
 
 function envKeysOf(step: Step): string[] {
   return Object.keys(step.env ?? {})

--- a/src/e2eWorkflowInvariants.test.ts
+++ b/src/e2eWorkflowInvariants.test.ts
@@ -197,7 +197,7 @@ describe('shared workflow policies', () => {
       for (const [jobId, job] of Object.entries(workflow.jobs)) {
         const isE2ESuiteCall =
           job.uses === './.github/workflows/e2e-reusable.yml' &&
-          jobId === 'create-and-delete'
+          jobId === 'e2e-deployment-test'
         if (isE2ESuiteCall) {
           expect(job.secrets).toBe('inherit')
         } else {
@@ -209,7 +209,7 @@ describe('shared workflow policies', () => {
 
   test('environment secrets can reach the called suite from both e2e callers', () => {
     for (const workflow of [e2eManual, e2eAutomatic]) {
-      expect(jobOf(workflow, 'create-and-delete').secrets).toBe('inherit')
+      expect(jobOf(workflow, 'e2e-deployment-test').secrets).toBe('inherit')
     }
   })
 
@@ -501,7 +501,7 @@ describe('e2e-manual', () => {
   })
 
   test('passes the digest-pinned candidate identity to the reusable suite', () => {
-    const caller = jobOf(e2eManual, 'create-and-delete')
+    const caller = jobOf(e2eManual, 'e2e-deployment-test')
     expect(caller.uses).toBe('./.github/workflows/e2e-reusable.yml')
     expect(caller.with?.['candidate_digest']).toBe(
       '${{ needs.candidate.outputs.digest }}'
@@ -580,7 +580,7 @@ describe('e2e-release-please', () => {
     expect(jobOf(e2eAutomatic, 'candidate').if).toBe(
       "needs.current-state.outputs.proceed == 'true'"
     )
-    expect(jobOf(e2eAutomatic, 'create-and-delete').if).toBe(
+    expect(jobOf(e2eAutomatic, 'e2e-deployment-test').if).toBe(
       "needs.current-state.outputs.proceed == 'true'"
     )
   })
@@ -632,7 +632,7 @@ describe('e2e-release-please', () => {
   })
 
   test('passes the digest-pinned candidate identity to the reusable suite', () => {
-    const caller = jobOf(e2eAutomatic, 'create-and-delete')
+    const caller = jobOf(e2eAutomatic, 'e2e-deployment-test')
     expect(caller.uses).toBe('./.github/workflows/e2e-reusable.yml')
     expect(caller.with?.['candidate_digest']).toBe(
       '${{ needs.candidate.outputs.digest }}'
@@ -653,7 +653,7 @@ describe('e2e-release-please', () => {
 })
 
 describe('e2e-reusable', () => {
-  const suiteJob = jobOf(e2eReusable, 'create-and-delete')
+  const suiteJob = jobOf(e2eReusable, 'e2e-deployment-test')
   const suiteSteps = suiteJob.steps ?? []
   const trustedScriptNames = [
     'validate-candidate-inputs.ts',


### PR DESCRIPTION
The old job name hid its role as the main end-to-end deployment test. Rename it across the reusable and calling workflows so GitHub presents that role clearly.

Checks: `CI=true pnpm test`